### PR TITLE
Re-factor bp_docs_tab() wrap orphaned bp_docs_create_button() in li tags

### DIFF
--- a/includes/templatetags.php
+++ b/includes/templatetags.php
@@ -1250,7 +1250,7 @@ add_action( 'bp_member_plugin_options_nav', 'bp_docs_member_create_button' );
  *
  * @since 1.2
  */
-function bp_docs_doc_permissions_snapshot( $args ) {
+function bp_docs_doc_permissions_snapshot( $args = '' ) {
 	$html = '';
 
  $defaults = array(


### PR DESCRIPTION
Wraps the create  new anchor in list tags otherwise anchor is child of ul. Add function arg to allow template file to pass a show button 'false' condition to remove button from doc_tabs, defaults to true = 'show', wraps li/button in checks for 'user_can'. arg filter mainly a convenience for developers who may need control & want to echo the button elsewhere - changes don't take into account other screens or circumstances.
