### PR TITLE
Attachments on hidden/private groups display blank page

### DIFF
--- a/includes/attachments.php
+++ b/includes/attachments.php
@@ -470,7 +470,9 @@ class BP_Docs_Attachments {
 	 */
 	public static function generate_headers( $filename ) {
 		// Disable compression
-		@apache_setenv( 'no-gzip', 1 );
+		if ( function_exists( 'apache_setenv' ) ) {
+			@apache_setenv( 'no-gzip', 1 );
+		}
 		@ini_set( 'zlib.output_compression', 'Off' );
 
 		// @todo Make this more configurable


### PR DESCRIPTION
On certain apache ( and non-apache ) environments when the apache_setenv function is not available, attempting to download attachment attached to hidden/private doc leads to a supressed fatal error / white screen.
