### PR TITLE
Adds ability to rename plugin dir name to something else

### DIFF
--- a/bp-docs.php
+++ b/bp-docs.php
@@ -168,9 +168,12 @@ class BP_Docs {
 	 * @since 1.0-beta
 	 */
 	function load_constants() {
+		if ( !defined( 'BP_DOCS_PLUGIN_SLUG' ) )
+			define( 'BP_DOCS_PLUGIN_SLUG', 'buddypress-docs/' );
+
 		// You should never really need to override this bad boy
 		if ( !defined( 'BP_DOCS_INSTALL_PATH' ) )
-			define( 'BP_DOCS_INSTALL_PATH', WP_PLUGIN_DIR . '/buddypress-docs/' );
+			define( 'BP_DOCS_INSTALL_PATH', WP_PLUGIN_DIR . DIRECTORY_SEPARATOR . BP_DOCS_PLUGIN_SLUG );
 
 		// Ditto
 		if ( !defined( 'BP_DOCS_INCLUDES_PATH' ) )

--- a/includes/attachments.php
+++ b/includes/attachments.php
@@ -336,7 +336,7 @@ class BP_Docs_Attachments {
 
 	function enqueue_scripts() {
 		if ( bp_docs_is_doc_edit() || bp_docs_is_doc_create() ) {
-			wp_enqueue_script( 'bp-docs-attachments', plugins_url( 'buddypress-docs/includes/js/attachments.js' ), array( 'media-editor', 'media-views' ), false, true );
+			wp_enqueue_script( 'bp-docs-attachments', plugins_url( BP_DOCS_PLUGIN_SLUG . 'includes/js/attachments.js' ), array( 'media-editor', 'media-views' ), false, true );
 		}
 	}
 
@@ -500,7 +500,7 @@ class BP_Docs_Attachments {
 
 	public static function icon_dir_uri( $url ) {
 		if ( bp_docs_is_docs_component() ) {
-			$url = plugins_url( 'buddypress-docs/lib/nuvola' );
+			$url = plugins_url( BP_DOCS_PLUGIN_SLUG . 'lib/nuvola' );
 		}
 		return $url;
 	}

--- a/includes/component.php
+++ b/includes/component.php
@@ -985,7 +985,7 @@ class BP_Docs_Component extends BP_Component {
 	 * @since 1.0-beta
 	 */
 	function set_includes_url() {
-		$this->includes_url = plugins_url() . '/buddypress-docs/includes/';
+		$this->includes_url = plugins_url() . BP_DOCS_PLUGIN_SLUG . 'includes/';
 	}
 
 	/**
@@ -1059,7 +1059,7 @@ class BP_Docs_Component extends BP_Component {
 	 * @since 1.0-beta
 	 */
 	function enqueue_scripts() {
-		wp_register_script( 'bp-docs-js', plugins_url( 'buddypress-docs/includes/js/bp-docs.js' ), array( 'jquery' ) );
+		wp_register_script( 'bp-docs-js', plugins_url( BP_DOCS_PLUGIN_SLUG . 'includes/js/bp-docs.js' ), array( 'jquery' ) );
 
 		// This is for edit/create scripts
 		if ( bp_docs_is_doc_edit()
@@ -1076,19 +1076,19 @@ class BP_Docs_Component extends BP_Component {
 			wp_enqueue_script( 'editor' );
 			wp_enqueue_script( 'utils' );
 
-			wp_register_script( 'bp-docs-idle-js', plugins_url( 'buddypress-docs/includes/js/idle.js' ), array( 'jquery', 'bp-docs-js' ) );
+			wp_register_script( 'bp-docs-idle-js', plugins_url( BP_DOCS_PLUGIN_SLUG . 'includes/js/idle.js' ), array( 'jquery', 'bp-docs-js' ) );
 			wp_enqueue_script( 'bp-docs-idle-js' );
 
-			wp_register_script( 'jquery-colorbox', plugins_url( 'buddypress-docs/lib/js/colorbox/jquery.colorbox-min.js' ), array( 'jquery' ) );
+			wp_register_script( 'jquery-colorbox', plugins_url( BP_DOCS_PLUGIN_SLUG . 'lib/js/colorbox/jquery.colorbox-min.js' ), array( 'jquery' ) );
 			wp_enqueue_script( 'jquery-colorbox' );
 			// Edit mode requires bp-docs-js to be dependent on TinyMCE, so we must
 			// reregister bp-docs-js with the correct dependencies
 			wp_deregister_script( 'bp-docs-js' );
-			wp_register_script( 'bp-docs-js', plugins_url( 'buddypress-docs/includes/js/bp-docs.js' ), array( 'jquery', 'editor' ) );
+			wp_register_script( 'bp-docs-js', plugins_url( BP_DOCS_PLUGIN_SLUG . 'includes/js/bp-docs.js' ), array( 'jquery', 'editor' ) );
 
 			wp_register_script( 'word-counter', site_url() . '/wp-admin/js/word-count.js', array( 'jquery' ) );
 
-			wp_enqueue_script( 'bp-docs-edit-validation', plugins_url( 'buddypress-docs/includes/js/edit-validation.js' ), array( 'jquery' ) );
+			wp_enqueue_script( 'bp-docs-edit-validation', plugins_url( BP_DOCS_PLUGIN_SLUG . 'includes/js/edit-validation.js' ), array( 'jquery' ) );
 		}
 
 		// Only load our JS on the right sorts of pages. Generous to account for

--- a/includes/templatetags-edit.php
+++ b/includes/templatetags-edit.php
@@ -238,9 +238,9 @@ add_filter( 'tiny_mce_before_init', 'bp_docs_add_idle_function_to_tinymce' );
  */
 function bp_docs_add_external_tinymce_plugins( $plugins ) {
 	if ( bp_docs_is_bp_docs_page() ) {
-		$plugins['table'] 	= WP_PLUGIN_URL . '/buddypress-docs/lib/js/tinymce/plugins/table/editor_plugin.js';
-		$plugins['tabindent'] 	= WP_PLUGIN_URL . '/buddypress-docs/lib/js/tinymce/plugins/tabindent/editor_plugin.js';
-		$plugins['print'] 	= WP_PLUGIN_URL . '/buddypress-docs/lib/js/tinymce/plugins/print/editor_plugin.js';
+		$plugins['table'] 	= WP_PLUGIN_URL . '/'. BP_DOCS_PLUGIN_SLUG .'/lib/js/tinymce/plugins/table/editor_plugin.js';
+		$plugins['tabindent'] 	= WP_PLUGIN_URL . '/'. BP_DOCS_PLUGIN_SLUG .'/lib/js/tinymce/plugins/tabindent/editor_plugin.js';
+		$plugins['print'] 	= WP_PLUGIN_URL . '/'. BP_DOCS_PLUGIN_SLUG .'/lib/js/tinymce/plugins/print/editor_plugin.js';
 	}
 
 	return $plugins;

--- a/includes/templatetags.php
+++ b/includes/templatetags.php
@@ -1856,7 +1856,7 @@ function bp_docs_attachment_icon() {
 		return;
 	}
 
-	$pc = plugins_url( 'buddypress-docs/includes/images/paperclip.png' );
+	$pc = plugins_url( BP_DOCS_PLUGIN_SLUG . 'includes/images/paperclip.png' );
 
 	$html = '<a class="bp-docs-attachment-clip" id="bp-docs-attachment-clip-' . get_the_ID() . '"><img src="' . $pc . '" height="25"></a>';
 


### PR DESCRIPTION
I needed to do this to work prevent my forked version to be overridden in a wp auto update.
