### PR TITLE
Add group ID as filter argument

### DIFF
--- a/includes/integration-groups.php
+++ b/includes/integration-groups.php
@@ -1001,7 +1001,7 @@ class BP_Docs_Group_Extension extends BP_Group_Extension {
 		$settings = apply_filters( 'bp_docs_default_group_settings', array(
 			'group-enable'	=> 1,
 			'can-create' 	=> 'member'
-		) );
+		), $group_id );
 
 		groups_update_groupmeta( $group_id, 'bp-docs', $settings );
 	}


### PR DESCRIPTION
The group id would be helpful to have when filtering the setting values in BP_Docs_Group_Extension::enable_at_group_creation().
