### PR TITLE
show doc counts in group and user tabs, fixes #423

### DIFF
--- a/includes/component.php
+++ b/includes/component.php
@@ -288,10 +288,10 @@ class BP_Docs_Component extends BP_Component {
 	function setup_nav( $main_nav = array(), $sub_nav = array() ) {
 
 		$main_nav = array(
-			'name' 		      => bp_docs_get_user_tab_name(),
+			//'name' 		      => bp_docs_get_user_tab_name(),
 
 			// Disabled count for now. See https://github.com/boonebgorges/buddypress-docs/issues/261
-			//'name' 		      => sprintf( __( 'Docs <span>%d</span>', 'bp-docs' ), bp_docs_get_doc_count( bp_displayed_user_id(), 'user' ) ),
+			'name' 		      => sprintf( __( 'Docs <span>%d</span>', 'bp-docs' ), bp_docs_get_doc_count( bp_displayed_user_id(), 'user' ) ),
 			'slug' 		      => bp_docs_get_docs_slug(),
 			'position' 	      => 80,
 			'screen_function'     => array( &$this, 'template_loader' ),

--- a/includes/integration-groups.php
+++ b/includes/integration-groups.php
@@ -60,8 +60,8 @@ class BP_Docs_Groups_Integration {
 		add_filter( 'bp_docs_hide_sitewide',		array( $this, 'hide_sitewide' ), 10, 5 );
 
 		// These functions are used to keep the group Doc count up to date
-		add_action( 'bp_docs_doc_saved',		array( $this, 'update_doc_count' ), 5 );
-		add_action( 'bp_docs_doc_deleted',		array( $this, 'update_doc_count' ), 5 );
+		add_action( 'bp_docs_doc_saved',		array( $this, 'update_doc_count' ) );
+		add_action( 'bp_docs_doc_deleted',		array( $this, 'update_doc_count' ) );
 
 		// On non-group Doc directories, add a Groups column
 		add_filter( 'bp_docs_loop_additional_th',       array( $this, 'groups_th' ), 5 );

--- a/includes/integration-groups.php
+++ b/includes/integration-groups.php
@@ -60,8 +60,8 @@ class BP_Docs_Groups_Integration {
 		add_filter( 'bp_docs_hide_sitewide',		array( $this, 'hide_sitewide' ), 10, 5 );
 
 		// These functions are used to keep the group Doc count up to date
-		add_filter( 'bp_docs_doc_saved',		array( $this, 'update_doc_count' )  );
-		add_filter( 'bp_docs_doc_deleted',		array( $this, 'update_doc_count' ) );
+		add_action( 'bp_docs_doc_saved',		array( $this, 'update_doc_count' ), 5 );
+		add_action( 'bp_docs_doc_deleted',		array( $this, 'update_doc_count' ), 5 );
 
 		// On non-group Doc directories, add a Groups column
 		add_filter( 'bp_docs_loop_additional_th',       array( $this, 'groups_th' ), 5 );
@@ -685,12 +685,24 @@ class BP_Docs_Groups_Integration {
 	function update_doc_count() {
 		global $bp;
 
-		// If this is not a group Doc, skip it
-		if ( !bp_is_group() )
-			return;
+		if ( array_key_exists( 'delete', $_GET ) ) { 
+			// We're deleting a doc. In the deleting context,
+			// we get useful information from `bp_docs_get_associated_group_id()`. 
+			$doc_id = is_singular() ? get_the_ID() : 0;
+			$group_id = bp_docs_get_associated_group_id( $doc_id );
+		} else if ( array_key_exists( 'group', $_GET ) ) { 
+			// We're creating a doc. In the doc creation context,
+			// we don't get anything useful from `bp_docs_get_associated_group_id()`, 
+			// so we have to figure out what group we're in by looking at the 
+			// $_GET variable that's passed during this step. 
+			$group_id = BP_Groups_Group::group_exists( $_GET['group'] ); 
+		} else {  
+			// If we're not creating or deleting a document, get outta here!
+			return; 
+		} 
 
-		// Get a fresh doc count for the group
-		bp_docs_update_doc_count( bp_get_current_group_id(), 'group' );
+		// Update the doc count for the group, since it has now changed. 
+		bp_docs_update_doc_count( $group_id, 'group' );
 	}
 
 	/**

--- a/includes/integration-groups.php
+++ b/includes/integration-groups.php
@@ -682,7 +682,7 @@ class BP_Docs_Groups_Integration {
 	 * @package BuddyPress Docs
 	 * @since 1.0.8
 	 */
-	function update_doc_count() {
+	function update_doc_count( $group_id = 0 ) {
 		global $bp;
 
 		if ( array_key_exists( 'delete', $_GET ) ) { 
@@ -696,8 +696,15 @@ class BP_Docs_Groups_Integration {
 			// so we have to figure out what group we're in by looking at the 
 			// $_GET variable that's passed during this step. 
 			$group_id = BP_Groups_Group::group_exists( $_GET['group'] ); 
+		} else if ( 0 !== $group_id ) {  
+			// If $group_id is passed through this function, 
+			// that means it's probably being called via show_doc_count_in_tab(). 
+			// This means that the doc count is probably '', which means this is probably 
+			// the first time this function has been run for this group. 
+			// Nothing to do here. Pass along through. 
 		} else {  
-			// If we're not creating or deleting a document, get outta here!
+			// If we're not creating or deleting a document, or updating for the first time,
+			// get outta here!
 			return; 
 		} 
 
@@ -849,12 +856,14 @@ class BP_Docs_Groups_Integration {
 		if ( !empty( $bp->bp_options_nav[$group_slug] ) && !empty( $bp->bp_options_nav[$group_slug][ $docs_slug ] ) ) {
 			$current_tab_name = $bp->bp_options_nav[$group_slug][ $docs_slug ]['name'];
 
-			$doc_count = groups_get_groupmeta( $bp->groups->current_group->id, 'bp-docs-count' );
+			$group_id = $bp->groups->current_group->id; 
+
+			$doc_count = groups_get_groupmeta( $group_id, 'bp-docs-count' );
 
 			// For backward compatibility
 			if ( '' === $doc_count ) {
-				BP_Docs_Groups_Integration::update_doc_count();
-				$doc_count = groups_get_groupmeta( $bp->groups->current_group->id, 'bp-docs-count' );
+				BP_Docs_Groups_Integration::update_doc_count( $group_id );
+				$doc_count = groups_get_groupmeta( $group_id, 'bp-docs-count' );
 			}
 
 			$bp->bp_options_nav[$group_slug][ $docs_slug ]['name'] = sprintf( __( '%s <span>%d</span>', 'bp-docs' ), $current_tab_name, $doc_count );

--- a/includes/integration-groups.php
+++ b/includes/integration-groups.php
@@ -75,7 +75,7 @@ class BP_Docs_Groups_Integration {
 		// Sneak into the nav before it's rendered to insert the group Doc count. Hooking
 		// to bp_actions because of the craptastic nature of the BP_Group_Extension loader
 		// @todo Temporarily disabled
-		//add_action( 'bp_actions',			array( $this, 'show_doc_count_in_tab' ), 9 );
+		add_action( 'bp_actions',			array( $this, 'show_doc_count_in_tab' ), 9 );
 
 		// Prettify the page title
 		add_filter( 'bp_page_title',			array( $this, 'page_title' ) );


### PR DESCRIPTION
Hi Boone, 

Here's my fix for our issue at mlaa/buddypress-docs#1, which may help out with #423 and #261. My understanding of the problem was: 

 * `update_doc_count()` wasn't working, because it relies on using `bp_is_group` to check whether we're creating or deleting a group document, and `bp_is_group` returned 0, because, judging from the slug  `/docs` at least, BP didn't know that it was in a group context.
 * it's possible that the hooks for `update_doc_count()` weren't working, since they were hooked in using `add_filter` instead of `add_action`, and the hooks `bp_docs_doc_saved` and `bp_docs_doc_deleted` appear to be action hooks instead of filter hooks.

This fixes the issue by rewriting `update_doc_count()` so that it can tell, through a variety of methods, what group the doc is associated with (if any), and update the groupmeta accordingly. It's probably not the most elegant solution, but seems to be working so far. 

Let me know what you think. 