### PR TITLE
Prevent Javascript errors

### DIFF
--- a/includes/js/bp-docs.js
+++ b/includes/js/bp-docs.js
@@ -274,7 +274,7 @@ function bp_docs_load_idle() {
 }
 
 function bp_docs_kitchen_sink(ed) {
-	var adv_button = jQuery('#' + ed.editorContainer).find('a.mce_wp_adv');
+	var adv_button = jQuery(ed.editorContainer).find('a.mce_wp_adv');
 	if ( 0 != adv_button.length ) {
 		jQuery(adv_button).on('click',function(e){
 			var sec_rows = jQuery(adv_button).closest('table.mceToolbar').siblings('table.mceToolbar');

--- a/includes/templatetags-edit.php
+++ b/includes/templatetags-edit.php
@@ -198,7 +198,7 @@ function bp_docs_add_idle_function_to_tinymce( $initArray ) {
 					bp_docs_load_idle();
 
 					/* Hide rows 3+ */
-					var rows = jQuery(\'#\' + ed.editorContainer).find(\'table.mceToolbar\');
+					var rows = jQuery(ed.editorContainer).find(\'table.mceToolbar\');
 					jQuery(rows).each(function(k,row){
 						if ( !jQuery(row).hasClass(\'mceToolbarRow2\') && !jQuery(row).hasClass(\'mceToolbarRow1\' ) ) {
 							jQuery(row).toggle();


### PR DESCRIPTION
BuddyPress Docs is throwing errors on "Create Doc" and "Edit Doc" pages because `ed.editorContainer` is not a string: 

> Uncaught Error: Syntax error, unrecognized expression: #[object HTMLDivElement]