### PR TITLE
When attachment is sent, exit (so footer is not sent)

### DIFF
--- a/includes/attachments.php
+++ b/includes/attachments.php
@@ -86,6 +86,7 @@ class BP_Docs_Attachments {
 			}
 
 			readfile( $filepath );
+			exit();
 		}
 	}
 


### PR DESCRIPTION
This fix prevent attachment corruption.
After readfile($attachment) application must exit, so Wordpress cannot concatenate a spurious HTML footer.