### PR TITLE
Archive pagination

### DIFF
--- a/includes/templatetags.php
+++ b/includes/templatetags.php
@@ -80,11 +80,14 @@ function bp_docs_has_docs( $args = array() ) {
 		$d_paged = 1;
 		if ( ! empty( $_GET['paged'] ) ) {
 			$d_paged = absint( $_GET['paged'] );
+			// Warn WP that we're using
 		} else if ( bp_docs_is_global_directory() && is_a( $wp_query, 'WP_Query' ) && 1 < $wp_query->get( 'paged' ) ) {
 			$d_paged = absint( $wp_query->get( 'paged' ) );
 		}
 
-		$d_posts_per_page = !empty( $_GET['posts_per_page'] ) ? absint( $_GET['posts_per_page'] ) : 10;
+		// Use the calculated posts_per_page number from $wp_query->query_vars.
+		// If that value isn't set, we assume 10 posts per page.
+		$d_posts_per_page = absint( $wp_query->get( 'posts_per_page', 10 ) );
 
 		// doc_slug
 		$d_doc_slug = !empty( $bp->bp_docs->query->doc_slug ) ? $bp->bp_docs->query->doc_slug : '';

--- a/includes/templatetags.php
+++ b/includes/templatetags.php
@@ -80,7 +80,6 @@ function bp_docs_has_docs( $args = array() ) {
 		$d_paged = 1;
 		if ( ! empty( $_GET['paged'] ) ) {
 			$d_paged = absint( $_GET['paged'] );
-			// Warn WP that we're using
 		} else if ( bp_docs_is_global_directory() && is_a( $wp_query, 'WP_Query' ) && 1 < $wp_query->get( 'paged' ) ) {
 			$d_paged = absint( $wp_query->get( 'paged' ) );
 		}


### PR DESCRIPTION
Hi Boone-

I think that the problem in #438 is that if you change the setting of "Blog pages show at most" to something other than 10 at `/wp-admin/options-reading.php`, pagination on the docs archive breaks. Using `$wp_query`'s `posts_per_page` setting corrects the pagination problems.

The underlying issue is that the SQL statement's LIMIT offset clause is built based on the `$wp_query->posts_per_page` value:
```
SELECT SQL_CALC_FOUND_ROWS  wp_posts.ID FROM wp_posts  WHERE 1=1  AND wp_posts.post_type = 'bp_doc' AND (wp_posts.post_status = 'publish' OR wp_posts.post_status = 'closed' OR wp_posts.post_status = 'private' OR wp_posts.post_status = 'hidden')  ORDER BY wp_posts.post_date DESC LIMIT 60, 15
```

And, in `bp_docs_paginate_links()` we're specifying the total number of pages from `$bp->bp_docs->doc_query->max_num_pages`. (Which is usually based on 10, so it guesses there are pages of results that don't actually exist.)

My approach uses that user setting, but, if it's important to use a number other than the user setting for the archive posts_per_page limit, I think we could use `$wp_query->set()` to force `posts_per_page` to work in the pagination and limit functions. 

Thanks!
