### PR TITLE
Don't use $_POST values in BP_Docs_Query->save().

### DIFF
--- a/includes/addon-hierarchy.php
+++ b/includes/addon-hierarchy.php
@@ -23,8 +23,8 @@ class BP_Docs_Hierarchy {
 		// Make sure that the bp_docs post type supports our post taxonomies
 		add_filter( 'bp_docs_post_type_args', array( $this, 'register_with_post_type' ) );
 
-		// Hook into post saves to save any taxonomy terms.
-		add_action( 'bp_docs_doc_saved', array( $this, 'save_post' ) );
+		// Set parent_id for posts saved from the front end
+		add_filter( 'bp_docs_get_parent_id_via_post', array( $this, 'set_parent_id_via_post' ) );
 
 		// Display a doc's parent on its single doc page
 		add_action( 'bp_docs_single_doc_meta', array( $this, 'show_parent' ) );
@@ -82,36 +82,20 @@ class BP_Docs_Hierarchy {
 	}
 
 	/**
-	 * Saves post parent to a doc when saved from the front end
+	 * Set parent_id for posts saved from the front end
 	 *
 	 * @package BuddyPress Docs
 	 * @since 1.0-beta
 	 *
-	 * @param object $query The query object created by BP_Docs_Query
-	 * @return int $post_id Returns the doc's post_id on success
+	 * @param int $parent_id The parent ID from BP_Docs_Query->save()
+	 * @return int $parent_id Returns the doc's parent_id on success
 	 */
-	function save_post( $query ) {
-		if ( empty( $query->doc_id ) ) {
-			return false;
+	function set_parent_id_via_post( $parent_id ) {
+		if ( ! empty( $_POST['parent_id'] ) ) {
+			$parent_id = $_POST['parent_id'];
 		}
 
-		$post_parent = !empty( $_POST['parent_id'] ) ? $_POST['parent_id'] : 0;
-
-		$args = array(
-			'ID' => $query->doc_id,
-			'post_parent' => $post_parent,
-		);
-
-		// Don't let a revision get saved here
-		remove_action( 'pre_post_update', 'wp_save_post_revision' );
-		$post_id = wp_update_post( $args );
-		add_action( 'pre_post_update', 'wp_save_post_revision' );
-
-		if ( $post_id ) {
-			return $post_id;
-		} else {
-			return false;
-		}
+		return $parent_id;
 	}
 
 	/**

--- a/includes/addon-taxonomy.php
+++ b/includes/addon-taxonomy.php
@@ -42,6 +42,9 @@ class BP_Docs_Taxonomy {
 		// Make sure that the bp_docs post type supports our post taxonomies
 		add_filter( 'bp_docs_init', array( $this, 'register_with_post_type' ), 12 );
 
+		// Hook into post save preparation to squeeze term information from $_POST
+		add_filter( 'bp_docs_prepare_terms_via_post', array( $this, 'prepare_terms_via_post' ) );
+
 		// Hook into post saves to save any taxonomy terms.
 		add_action( 'bp_docs_doc_saved', 	array( $this, 'save_post' ) );
 
@@ -113,22 +116,23 @@ class BP_Docs_Taxonomy {
 	}
 
 	/**
-	 * Saves post taxonomy terms to a doc when saved from the front end
+	 * Hook into post save preparation to squeeze term information from $_POST
 	 *
 	 * @package BuddyPress Docs
-	 * @since 1.0-beta
+	 * @since 1.9
 	 *
-	 * @param object $query The query object created by BP_Docs_Query
-	 * @return int $post_id Returns the doc's post_id on success
+	 * @return array $tax_name => (array) $terms
 	 */
-	function save_post( $query ) {
+	function prepare_terms_via_post( $terms_array ) {
+
 		foreach ( $this->taxonomies as $tax_name ) {
 
-			if ( $tax_name == 'category' )
+			if ( $tax_name == 'category' ) {
 				$tax_name = 'post_category';
+			}
 
 			// Separate out the terms
-			$terms = !empty( $_POST[$tax_name] ) ? explode( ',', $_POST[$tax_name] ) : array();
+			$terms = ! empty( $_POST[$tax_name] ) ? explode( ',', $_POST[$tax_name] ) : array();
 
 			// Strip whitespace from the terms
 			foreach ( $terms as $key => $term ) {
@@ -139,17 +143,28 @@ class BP_Docs_Taxonomy {
 
 			// Hierarchical terms like categories have to be handled differently, with
 			// term IDs rather than the term names themselves
-			if ( !empty( $tax->hierarchical ) ) {
+			if ( ! empty( $tax->hierarchical ) ) {
 				$term_ids = array();
 				foreach( $terms as $term ) {
 					$parent = 0;
 					$term_ids[] = term_exists( $term, $tax_id, $parent );
 				}
 			}
-
-			wp_set_post_terms( $query->doc_id, $terms, $tax_name );
+			$terms_array[$tax_name] = $terms;
 		}
+		return $terms_array;
+	}
 
+	/**
+	 * Saves post taxonomy terms to a doc when saved from the front end
+	 *
+	 * @package BuddyPress Docs
+	 * @since 1.0-beta
+	 *
+	 * @param object $query The query object created by BP_Docs_Query
+	 * @return int $post_id Returns the doc's post_id on success
+	 */
+	function save_post( $query ) {
 		do_action( 'bp_docs_taxonomy_saved', $query );
 	}
 

--- a/includes/component.php
+++ b/includes/component.php
@@ -379,8 +379,7 @@ class BP_Docs_Component extends BP_Component {
 
 			check_admin_referer( 'bp_docs_save' );
 
-			$this_doc = new BP_Docs_Query;
-			$result = $this_doc->save();
+			$result = bp_docs_save_doc_via_post();
 
 			bp_core_add_message( $result['message'], $result['message_type'] );
 			bp_core_redirect( trailingslashit( $result['redirect_url'] ) );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -874,9 +874,9 @@ function bp_docs_save_doc_via_post() {
 	// Using WP editor necessitated the change to $_POST['doc_content'].
 	// Maintain backward compatibility by checking $_POST['doc']['content'] too.
 	if ( isset( $_POST['doc_content'] ) ) {
-		$args['content'] = $_POST['doc_content'];
+		$args['content'] = sanitize_post_field( 'post_content', $_POST['doc_content'], 0, 'db' );
 	} else if ( isset( $_POST['doc']['content'] ) ) {
-		$args['content'] = $_POST['doc']['content'];
+		$args['content'] = sanitize_post_field( 'post_content', $_POST['doc']['content'], 0, 'db' );
 	}
 
 	$args['permalink'] = isset( $_POST['doc']['permalink'] ) ? sanitize_title( $_POST['doc']['permalink'] ) : sanitize_title( $_POST['doc']['title'] );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -835,15 +835,21 @@ function bp_docs_revisions_to_keep( $num, $post ) {
 add_filter( 'wp_revisions_to_keep', 'bp_docs_revisions_to_keep', 10, 2 );
 
 /**
- * Wrapper to the BP_Docs_Query->save() method for docs saved via the create/edit screens.
- * Creates an args array from $_POST in the format that BP_Docs_Query->save() expects.
+ * Wrapper to the BP_Docs_Query->save() method for docs saved via the
+ * create/edit screens. Creates an args array from $_POST in the format that
+ * BP_Docs_Query->save() expects.
  *
  * @since 1.9
  *
- * @return boolean (success)
+ * @return array created in BP_Docs_Query->save() {
+ *		  @type string $message_type Type of message, success or error.
+ *		  @type string $message Text of message to display to user.
+ *		  @type string $redirect_url URL to use for redirect after save.
+ *		  @type int    $doc_id ID of the updated doc, if applicable.
+ *        }
  */
 function bp_docs_save_doc_via_post() {
-	// Defaults for the args that the save() method is expecting:
+	// Defaults for the array of args that the save() method is expecting:
 	$args = array(
 		'doc_id'      => 0,
 		'title'       => '',

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -556,22 +556,27 @@ function bp_docs_get_access_options( $settings_field, $doc_id = 0, $group_id = 0
  *
  * @since 1.6.1
  * @param int $doc_id The numeric ID of the doc
- * @return null
+ * @return string Notice of access setting modification
  */
-function bp_docs_save_doc_access_settings( $doc_id ) {
+function bp_docs_save_doc_access_settings( $doc_id, $author_id, $settings ) {
+	if ( empty( $author_id ) ) {
+		$author_id = bp_loggedin_user_id();
+	}
+	$message = '';
+
 	// Two cases:
 	// 1. User is saving a doc for which he can update the access settings
-	if ( isset( $_POST['settings'] ) ) {
-		$settings = ! empty( $_POST['settings'] ) ? $_POST['settings'] : array();
-		$verified_settings = bp_docs_verify_settings( $settings, $doc_id, bp_loggedin_user_id() );
+	if ( ! empty( $settings ) ) {
+		$verified_settings = bp_docs_verify_settings( $settings, $doc_id, $author_id );
 
 		$new_settings = array();
 		foreach ( $verified_settings as $verified_setting_name => $verified_setting ) {
 			$new_settings[ $verified_setting_name ] = $verified_setting['verified_value'];
 			if ( $verified_setting['verified_value'] != $verified_setting['original_value'] ) {
-				$result['message'] = __( 'Your Doc was successfully saved, but some of your access settings have been changed to match the Doc\'s permissions.', 'bp-docs' );
+				$message = __( 'Your Doc was successfully saved, but some of your access settings have been changed to match the Doc\'s permissions.', 'bp-docs' );
 			}
 		}
+
 		update_post_meta( $doc_id, 'bp_docs_settings', $new_settings );
 
 		// The 'read' setting must also be saved to a taxonomy, for
@@ -586,6 +591,8 @@ function bp_docs_save_doc_access_settings( $doc_id ) {
 		// Do nothing.
 		// Leave the access settings intact.
 	}
+
+	return $message;
 }
 
 /**
@@ -826,3 +833,66 @@ function bp_docs_revisions_to_keep( $num, $post ) {
 	return intval( $num );
 }
 add_filter( 'wp_revisions_to_keep', 'bp_docs_revisions_to_keep', 10, 2 );
+
+/**
+ * Wrapper to the BP_Docs_Query->save() method for docs saved via the create/edit screens.
+ * Creates an args array from $_POST in the format that BP_Docs_Query->save() expects.
+ *
+ * @since 1.9
+ *
+ * @return boolean (success)
+ */
+function bp_docs_save_doc_via_post() {
+	// Defaults for the args that the save() method is expecting:
+	$args = array(
+		'doc_id'      => 0,
+		'title'       => '',
+		'content'     => '',
+		'permalink'   => '',
+		'author_id'   => 0,
+		'group_id'    => null, // Value of null does nothing; 0 will unset existing group association.
+		'is_auto'     => 0,
+		'taxonomies'  => array(),
+		'settings'    => array(),
+		'parent_id'   => 0,
+		);
+
+	if ( isset( $_POST['doc_id'] ) && 0 != $_POST['doc_id'] ) {
+		$args['doc_id'] = (int) $_POST['doc_id'];
+	}
+
+	if ( isset( $_POST['doc']['title'] ) ) {
+		$args['title'] = $_POST['doc']['title'];
+	}
+
+	// Using WP editor necessitated the change to $_POST['doc_content'].
+	// Maintain backward compatibility by checking $_POST['doc']['content'] too.
+	if ( isset( $_POST['doc_content'] ) ) {
+		$args['content'] = $_POST['doc_content'];
+	} else if ( isset( $_POST['doc']['content'] ) ) {
+		$args['content'] = $_POST['doc']['content'];
+	}
+
+	$args['permalink'] = isset( $_POST['doc']['permalink'] ) ? sanitize_title( $_POST['doc']['permalink'] ) : sanitize_title( $_POST['doc']['title'] );
+
+	$args['author_id'] = bp_loggedin_user_id();
+
+	if ( isset( $_POST['associated_group_id'] ) ) {
+		$args['group_id'] = intval( $_POST['associated_group_id'] );
+	}
+
+	if ( ! empty( $_POST['is_auto'] ) && $_POST['is_auto'] ) {
+		$args['is_auto'] = $_POST['is_auto'];
+	}
+
+	$args['taxonomies'] = apply_filters( 'bp_docs_prepare_terms_via_post', $args['taxonomies'] );
+
+	if ( ! empty( $_POST['settings'] ) ) {
+		$args['settings'] = $_POST['settings'];
+	}
+
+	$args['parent_id'] = apply_filters( 'bp_docs_get_parent_id_via_post', $args['parent_id'] );
+
+	$instance = new BP_Docs_Query;
+	return $instance->save( $args );
+}

--- a/includes/integration-groups.php
+++ b/includes/integration-groups.php
@@ -1703,11 +1703,6 @@ function bp_docs_groups_map_meta_caps( $caps, $cap, $user_id, $args ) {
 				$group_id = bp_get_current_group_id();
 			}
 
-			// If this request was sent from BP_Docs_Query->save, it will include the author user_id as an extra argument.
-			if ( isset( $args[1] ) ) {
-				$user_id = intval( $args[1] );
-			}
-
 			if ( empty( $group_id ) ) {
 				break;
 			}

--- a/includes/integration-groups.php
+++ b/includes/integration-groups.php
@@ -1703,6 +1703,11 @@ function bp_docs_groups_map_meta_caps( $caps, $cap, $user_id, $args ) {
 				$group_id = bp_get_current_group_id();
 			}
 
+			// If this request was sent from BP_Docs_Query->save, it will include the author user_id as an extra argument.
+			if ( isset( $args[1] ) ) {
+				$user_id = intval( $args[1] );
+			}
+
 			if ( empty( $group_id ) ) {
 				break;
 			}

--- a/includes/query-builder.php
+++ b/includes/query-builder.php
@@ -501,7 +501,7 @@ class BP_Docs_Query {
 				'post_type'    => $this->post_type_name,
 				'post_title'   => $args['title'],
 				'post_name'    => $args['permalink'],
-				'post_content' => sanitize_post_field( 'post_content', $args['content'], 0, 'db' ),
+				'post_content' => $args['content'],
 				'post_status'  => 'publish',
 				'post_parent'  => $args['parent_id']
 			);

--- a/includes/query-builder.php
+++ b/includes/query-builder.php
@@ -395,7 +395,7 @@ class BP_Docs_Query {
 		if ( bp_is_active( 'groups' ) ) {
 			// Check whether the user can associate the doc with the group.
 			// $args['group_id'] could be null (untouched) or 0, which unsets existing association
-			if ( ! empty( $args['group_id'] ) && ! current_user_can( 'bp_docs_associate_with_group', $args['group_id'], $args['author_id'] ) ) {
+			if ( ! empty( $args['group_id'] ) && ! user_can( $args['author_id'], 'bp_docs_associate_with_group', $args['group_id'] ) ) {
 				$retval = array(
 					'message_type' => 'error',
 					'message' => __( 'You are not allowed to associate a Doc with that group.', 'bp-docs' ),

--- a/includes/query-builder.php
+++ b/includes/query-builder.php
@@ -497,10 +497,6 @@ class BP_Docs_Query {
 				bp_docs_set_associated_group_id( $post_id, $args['group_id'] );
 			}
 
-			// Make sure the current user is added as one of the authors
-			// @TODO: Is this still used?
-			wp_set_post_terms( $post_id, $this->user_term_id, $this->associated_item_tax_name, true );
-
 			// Save the last editor id. We'll use this to create an activity item
 			update_post_meta( $this->doc_id, 'bp_docs_last_editor', $args['author_id'] );
 

--- a/includes/query-builder.php
+++ b/includes/query-builder.php
@@ -403,11 +403,40 @@ class BP_Docs_Query {
 	/**
 	 * Saves a doc.
 	 *
-	 * This method handles saving for both new and existing docs. It detects the difference by
-	 * looking for the presence of $this->doc_slug
+	 * This method handles saving for both new and existing docs. It detects the
+	 * difference by looking for the presence of $this->doc_slug
 	 *
 	 * @package BuddyPress Docs
 	 * @since 1.0-beta
+	 *
+	 * @param array $passed_args {
+	 *	      @type int    $doc_id ID of the doc, if it already exists.
+	 *	      @type string $title Doc title.
+	 *	      @type string $content Doc content.
+	 *	      @type string $permalink Optional. Permalink will be calculated if
+	 *                     if not specified.
+	 *	      @type int    $author_id ID of the user submitting the changes.
+	 *	      @type int    $group_id ID of the associated group, if any.
+	 *                     Special cases: Passing "null" leaves current group
+	 *                     associations intact. Passing 0 will unset existing
+	 *                     group associations.
+	 *	      @type bool   $is_auto Is this an autodraft?
+	 *	      @type array  $taxonomies Taxonomy terms to apply to the doc.
+	 *                     Use the form: array( $tax_name => (array) $terms ).
+	 *	      @type array  $settings Doc access settings. Of the form:
+	 *                     array( 'read' => 'group-members',
+	 *                            'edit' => 'admins-mods',
+	 *                            'read_comments' => 'group-members',
+	 *                            'post_comments' => 'group-members',
+	 *                            'view_history' => 'creator' )
+	 *	      @type int   $parent_id The ID of the parent doc, if applicable.
+	 *        }
+	 * @return array {
+	 *		  @type string $message_type Type of message, success or error.
+	 *		  @type string $message Text of message to display to user.
+	 *		  @type string $redirect_url URL to use for redirect after save.
+	 *		  @type int    $doc_id ID of the updated doc, if applicable.
+	 *        }
 	 */
 	function save( $passed_args = false ) {
 		$bp = buddypress();
@@ -419,9 +448,9 @@ class BP_Docs_Query {
 			'content' 		=> '',
 			'permalink'		=> '',
 			'author_id'		=> bp_loggedin_user_id(),
-			'group_id'		=> null, // Value of null does nothing; 0 will unset existing group association.
+			'group_id'		=> null,
 			'is_auto'		=> 0,
-			'taxonomies'	=> array(), // expecting the form: array( $tax_name => (array) $terms )
+			'taxonomies'	=> array(),
 			'settings'		=> array(),
 			'parent_id'		=> 0,
 			);

--- a/includes/query-builder.php
+++ b/includes/query-builder.php
@@ -409,15 +409,31 @@ class BP_Docs_Query {
 	 * @package BuddyPress Docs
 	 * @since 1.0-beta
 	 */
-	function save( $args = false ) {
-		global $bp;
+	function save( $passed_args = false ) {
+		$bp = buddypress();
+
+		// Sensible defaults
+		$defaults = array(
+			'doc_id' 		=> 0,
+			'title'			=> '',
+			'content' 		=> '',
+			'permalink'		=> '',
+			'author_id'		=> bp_loggedin_user_id(),
+			'group_id'		=> null, // Value of null does nothing; 0 will unset existing group association.
+			'is_auto'		=> 0,
+			'taxonomies'	=> array(), // expecting the form: array( $tax_name => (array) $terms )
+			'settings'		=> array(),
+			'parent_id'		=> 0,
+			);
+
+		$args = wp_parse_args( $passed_args, $defaults );
 
 		// bbPress plays naughty with revision saving
 		add_action( 'pre_post_update', 'wp_save_post_revision' );
 
 		// Get the required taxonomy items associated with the group. We only run this
 		// on a save because it requires extra database hits.
-		$this->setup_terms();
+		$this->setup_terms(); // @TODO: Not sure what this is doing
 
 		// Set up the default value for the result message
 		$results = array(
@@ -425,55 +441,52 @@ class BP_Docs_Query {
 			'redirect' => 'create'
 		);
 
-		// Backward compatibility. Had to change to doc_content to work with wp_editor
-		$doc_content = '';
-		if ( isset( $_POST['doc_content'] ) ) {
-			$doc_content = $_POST['doc_content'];
-		} else if ( isset( $_POST['doc']['content'] ) ) {
-			$doc_content = $_POST['doc']['content'];
-		}
-
 		// Check group associations
 		// @todo Move into group integration piece
 		if ( bp_is_active( 'groups' ) ) {
-			// This group id is only used to check whether the user can associate the doc with the group.
-			$associated_group_id = isset( $_POST['associated_group_id'] ) ? intval( $_POST['associated_group_id'] ) : null;
-
-			if ( ! empty( $associated_group_id ) && ! current_user_can( 'bp_docs_associate_with_group', $associated_group_id ) ) {
+			// Check whether the user can associate the doc with the group.
+			// $args['group_id'] could be null (untouched) or 0, which unsets existing association
+			if ( ! empty( $args['group_id'] ) && ! current_user_can( 'bp_docs_associate_with_group', $args['group_id'], $args['author_id'] ) ) {
 				$retval = array(
 					'message_type' => 'error',
 					'message' => __( 'You are not allowed to associate a Doc with that group.', 'bp-docs' ),
 					'redirect_url' => bp_docs_get_create_link(),
 				);
-
 				return $retval;
 			}
 		}
 
-		if ( empty( $_POST['doc']['title'] ) ) {
+		if ( empty( $args['title'] ) ) {
 			// The title field is required
 			$result['message'] = __( 'The title field is required.', 'bp-docs' );
 			$result['redirect'] = ! empty( $this->doc_slug ) ? 'edit' : 'create';
 		} else {
-			$defaults = array(
-				'post_type'    => $this->post_type_name,
-				'post_title'   => $_POST['doc']['title'],
-				'post_name'    => isset( $_POST['doc']['permalink'] ) ? sanitize_title( $_POST['doc']['permalink'] ) : sanitize_title( $_POST['doc']['title'] ),
-				'post_content' => sanitize_post_field( 'post_content', $doc_content, 0, 'db' ),
-				'post_status'  => 'publish'
-			);
+			// Use the passed permalink if it exists, otherwise create one
+			if ( ! empty( $args['permalink'] ) ) {
+				$args['permalink'] = sanitize_title( $args['permalink'] );
+			} else {
+				$args['permalink'] = sanitize_title( $args['title'] );
+			}
 
-			$r = wp_parse_args( $args, $defaults );
+			$r = array(
+				'post_type'    => $this->post_type_name,
+				'post_title'   => $args['title'],
+				'post_name'    => $args['permalink'],
+				'post_content' => sanitize_post_field( 'post_content', $args['content'], 0, 'db' ),
+				'post_status'  => 'publish',
+				'post_parent'  => $args['parent_id']
+			);
 
 			if ( empty( $this->doc_slug ) ) {
 				$this->is_new_doc = true;
 
-				$r['post_author'] = bp_loggedin_user_id();
+				// We only save the author for new docs.
+				$r['post_author'] = $args['author_id'];
 
-				// If there's a 'doc_id' value in the POST, use
-				// the autodraft as a starting point
-				if ( isset( $_POST['doc_id'] ) && 0 != $_POST['doc_id'] ) {
-					$post_id = (int) $_POST['doc_id'];
+				// If there's a 'doc_id' value use
+				// the autodraft as a starting point.
+				if ( 0 != $args['doc_id'] ) {
+					$post_id = (int) $args['doc_id'];
 					$r['ID'] = $post_id;
 					wp_update_post( $r );
 				} else {
@@ -496,21 +509,15 @@ class BP_Docs_Query {
 			} else {
 				$this->is_new_doc = false;
 
-				$doc = bp_docs_get_current_doc();
-
-				$this->doc_id = $doc->ID;
+				$this->doc_id = $args['doc_id'];
 				$r['ID']      = $this->doc_id;
 
-				// Make sure the post_name is set
-				if ( empty( $r['post_name'] ) )
-					$r['post_name'] = sanitize_title( $r['post_title'] );
-
-				// Make sure the post_name is unique
-				$r['post_name'] = wp_unique_post_slug( $r['post_name'], $this->doc_id, $r['post_status'], $this->post_type_name, $doc->post_parent );
+				// Make sure the post_name is unique, wp_unique_post_slug requires a post_id
+				$r['post_name'] = wp_unique_post_slug( $r['post_name'], $this->doc_id, $r['post_status'], $this->post_type_name, $r['post_parent'] );
 
 				$this->doc_slug = $r['post_name'];
 
-				if ( !wp_update_post( $r ) ) {
+				if ( ! wp_update_post( $r ) ) {
 					$result['message'] = __( 'There was an error when saving the doc.', 'bp-docs' );
 					$result['redirect'] = 'edit';
 				} else {
@@ -520,7 +527,7 @@ class BP_Docs_Query {
 
 					// When the post has been autosaved, we need to leave a
 					// special success message
-					if ( !empty( $_POST['is_auto'] ) && $_POST['is_auto'] ) {
+					if ( ! empty( $args['is_auto'] ) && $args['is_auto'] ) {
 						$result['message'] = __( 'You idled a bit too long while in Edit mode. In order to allow others to edit the doc you were working on, your changes have been autosaved. Click the Edit button to return to Edit mode.', 'bp-docs' );
 					} else {
 						// A normal, successful save
@@ -537,18 +544,26 @@ class BP_Docs_Query {
 		if ( ! empty( $post_id ) ) {
 
 			// Add to a group, if necessary
-			if ( ! is_null( $associated_group_id ) ) {
-				bp_docs_set_associated_group_id( $post_id, $associated_group_id );
+			if ( ! is_null( $args['group_id'] ) ) {
+				bp_docs_set_associated_group_id( $post_id, $args['group_id'] );
 			}
 
 			// Make sure the current user is added as one of the authors
+			// @TODO: Is this still used?
 			wp_set_post_terms( $post_id, $this->user_term_id, $this->associated_item_tax_name, true );
 
 			// Save the last editor id. We'll use this to create an activity item
-			update_post_meta( $this->doc_id, 'bp_docs_last_editor', bp_loggedin_user_id() );
+			update_post_meta( $this->doc_id, 'bp_docs_last_editor', $args['author_id'] );
 
-			// Save settings
-			bp_docs_save_doc_access_settings( $this->doc_id );
+			// Update taxonomies if necessary
+			if ( ! empty( $args['taxonomies'] ) ) {
+				foreach ( $args['taxonomies'] as $tax_name => $terms ) {
+					wp_set_post_terms( $post_id, $terms, $tax_name );
+				}
+			}
+
+			// Save settings. We append the notice message if necessary.
+			$result['message'] .= bp_docs_save_doc_access_settings( $this->doc_id, $args['author_id'], $args['settings'] );
 
 			// Increment the revision count
 			$revision_count = get_post_meta( $this->doc_id, 'bp_docs_revision_count', true );
@@ -581,9 +596,10 @@ class BP_Docs_Query {
 		}
 
 		$retval = array(
-			'message_type' => $message_type,
-			'message' => $result['message'],
-			'redirect_url' => $redirect_url,
+			'message_type' 	=> $message_type,
+			'message' 		=> $result['message'],
+			'redirect_url' 	=> $redirect_url,
+			'doc_id' 		=> $this->doc_id,
 		);
 
 		return $retval;


### PR DESCRIPTION
Hi Boone-

I revisited the code for restructuring the save functions so that `save()` doesn't rely on `$_POST` values directly.

I'll need the ability to create docs programatically for an upcoming project where content created on another system will generate docs on mine, so let me know what I can do to improve the code or write new tests.

Thanks for the great plugin!

-David
