### PR TITLE
Edit link redux

### DIFF
--- a/includes/templatetags.php
+++ b/includes/templatetags.php
@@ -950,7 +950,7 @@ function bp_docs_doc_action_links() {
 	$links[] = '<a href="' . bp_docs_get_doc_link() . '">' . __( 'Read', 'bp-docs' ) . '</a>';
 
 	if ( current_user_can( 'bp_docs_edit', get_the_ID() ) ) {
-		$links[] = '<a href="' . bp_docs_get_doc_link() . BP_DOCS_EDIT_SLUG . '">' . __( 'Edit', 'bp-docs' ) . '</a>';
+		$links[] = '<a href="' . bp_docs_get_doc_edit_link() . '">' . __( 'Edit', 'bp-docs' ) . '</a>';
 	}
 
 	if ( current_user_can( 'bp_docs_view_history', get_the_ID() ) && defined( 'WP_POST_REVISIONS' ) && WP_POST_REVISIONS ) {

--- a/includes/templatetags.php
+++ b/includes/templatetags.php
@@ -80,11 +80,14 @@ function bp_docs_has_docs( $args = array() ) {
 		$d_paged = 1;
 		if ( ! empty( $_GET['paged'] ) ) {
 			$d_paged = absint( $_GET['paged'] );
+			// Warn WP that we're using
 		} else if ( bp_docs_is_global_directory() && is_a( $wp_query, 'WP_Query' ) && 1 < $wp_query->get( 'paged' ) ) {
 			$d_paged = absint( $wp_query->get( 'paged' ) );
 		}
 
-		$d_posts_per_page = !empty( $_GET['posts_per_page'] ) ? absint( $_GET['posts_per_page'] ) : 10;
+		// Use the calculated posts_per_page number from $wp_query->query_vars.
+		// If that value isn't set, we assume 10 posts per page.
+		$d_posts_per_page = absint( $wp_query->get( 'posts_per_page', 10 ) );
 
 		// doc_slug
 		$d_doc_slug = !empty( $bp->bp_docs->query->doc_slug ) ? $bp->bp_docs->query->doc_slug : '';

--- a/includes/templatetags.php
+++ b/includes/templatetags.php
@@ -80,7 +80,6 @@ function bp_docs_has_docs( $args = array() ) {
 		$d_paged = 1;
 		if ( ! empty( $_GET['paged'] ) ) {
 			$d_paged = absint( $_GET['paged'] );
-			// Warn WP that we're using
 		} else if ( bp_docs_is_global_directory() && is_a( $wp_query, 'WP_Query' ) && 1 < $wp_query->get( 'paged' ) ) {
 			$d_paged = absint( $wp_query->get( 'paged' ) );
 		}


### PR DESCRIPTION
Hi Boone-

While doing some filtering of template items, I saw that in `bp_docs_doc_action_links()` the edit link was being generated  in an un-filterable way (this is used in `docs-loop.php`). I've switched it to use the filterable version as used in `bp-docs-header.php`. The only useful commit here is b15030661e617decc6e04f8991543c135a384ec0.

Thanks!

-David