### PR TITLE
Assume BP Docs is not enabled unless explicitly enabled.

### DIFF
--- a/includes/integration-groups.php
+++ b/includes/integration-groups.php
@@ -359,11 +359,6 @@ class BP_Docs_Groups_Integration {
 			case 'associate_with_group' :
 				$group_settings = bp_docs_get_group_settings( $group_id );
 
-				// Provide a default value for legacy backpat
-				if ( empty( $group_settings['can-create'] ) ) {
-					$group_settings['can-create'] = 'member';
-				}
-
 				if ( !empty( $group_settings['can-create'] ) ) {
 					switch ( $group_settings['can-create'] ) {
 						case 'admin' :
@@ -536,14 +531,12 @@ class BP_Docs_Groups_Integration {
 			return false;
 		}
 
-		// Check against group settings. Default to 'member'
-		// @todo Abstract default settings out better
+		// Check against group settings.
 		$group_settings = bp_docs_get_group_settings( $group_id );
-		$can_create = isset( $group_settings['can-create'] ) ? $group_settings['can-create'] : 'member';
 
-		if ( 'admin' == $can_create ) {
+		if ( 'admin' == $group_settings['can-create'] ) {
 			return (bool) groups_is_user_admin( $user_id, $group_id );
-		} else if ( 'mod' == $can_create ) {
+		} else if ( 'mod' == $group_settings['can-create'] ) {
 			return groups_is_user_admin( $user_id, $group_id ) || groups_is_user_mod( $user_id, $group_id );
 		}
 
@@ -1625,7 +1618,7 @@ function bp_docs_get_group_settings( $group_id ) {
 	}
 
 	$parsed_settings = wp_parse_args( $settings, array(
-		'group-enable'	=> 1,
+		'group-enable'	=> 0,
 		'can-create' 	=> 'member',
 	) );
 


### PR DESCRIPTION
When BuddyPress Docs, via `bp_docs_get_group_settings()`, cannot find
the “bp-docs” groupmeta entry for a group, it assumes that the plugin
is active for the group. This causes poor behavior when the groupmeta
doesn’t exist. An example is when the plugin is activated after groups
are created.

Also remove some extra settings checks that are not needed because
default values are set in `bp_docs_get_group_settings()`.