### PR TITLE
Fix `$( '#associated_group_id' ).val() is undefined` error.

### DIFF
--- a/includes/js/folders.js
+++ b/includes/js/folders.js
@@ -69,8 +69,12 @@
 		init_doc_drag();
 	} );
 
+	/**
+	 * Folder functionality only applies to groups, so only display meta box
+	 * if a group is selected.
+	 */
 	function update_folder_metabox_display() {
-		if ( $( '#associated_group_id' ).val().length ) {
+		if ( $( '#associated_group_id' ).length && $( '#associated_group_id' ).val().length ) {
 			$( '#doc-folders' ).show();
 		} else {
 			$( '#doc-folders' ).hide();


### PR DESCRIPTION
Check for the existence of `#associated_group_id` before attempting to
retrieve its value. Needed to avoid an `$( '#associated_group_id'
).val() is undefined` error on the docs directory.

======

Hi Boone-

I'm sure there are other ways to fix this problem (the undefined error was breaking all js on the docs directory pages) like splitting the `folders.js` file into what's needed on the edit screen and what's needed to handle the directory display. Or internally splitting the js into edit and display and only running what's needed at document ready based on knowing where you are. Anyway, this PR is the path of least resistance, but maybe not the most elegant. Let me know if there's something else I can do to be helpful.

-David