### PR TITLE
Accessibility for frontend and backend screens

### DIFF
--- a/includes/addon-history.php
+++ b/includes/addon-history.php
@@ -389,8 +389,8 @@ function bp_docs_list_post_revisions( $post_id = 0, $args = null ) {
 				$actions = '';
 
 			$rows .= "<tr$class>\n";
-			$rows .= "\t<th style='white-space: nowrap' scope='row'><input type='radio' name='left' value='$revision->ID'$left_checked /></th>\n";
-			$rows .= "\t<th style='white-space: nowrap' scope='row'><input type='radio' name='right' value='$revision->ID'$right_checked /></th>\n";
+			$rows .= "\t<th style='white-space:nowrap;text-align:center' scope='row'><input type='radio' name='left' value='$revision->ID'$left_checked id='left-$revision->ID' /><label class='screen-reader-text' for='left-$revision->ID'>" . __( 'Old', 'bp-docs' ) . "</label></th>\n";
+			$rows .= "\t<th style='white-space:nowrap;text-align:center' scope='row'><input type='radio' name='right' value='$revision->ID'$right_checked id='right-$revision->ID' /><label class='screen-reader-text' for='right-$revision->ID'>" . __( 'New', 'bp-docs' ) . "</label></th>\n";
 			$rows .= "\t<td>$date</td>\n";
 			$rows .= "\t<td>$name</td>\n";
 			$rows .= "\t<td class='action-links'>$actions</td>\n";

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -148,6 +148,7 @@ class BP_Docs_Admin {
 		$is_in_wp_config = 1 === $bp->bp_docs->slug_defined_in_wp_config['slug'];
 
 		?>
+		<label for="bp-docs-slug" class="screen-reader-text"><?php _e( "Change the slug used to build Docs URLs.", 'bp-docs' ) ?></label>
 		<input name="bp-docs-slug" id="bp-docs-slug" type="text" value="<?php echo esc_html( $slug ) ?>" <?php if ( $is_in_wp_config ) : ?>disabled="disabled" <?php endif ?>/>
 		<p class="description"><?php _e( "Change the slug used to build Docs URLs.", 'bp-docs' ) ?><?php if ( $is_in_wp_config ) : ?> <?php _e( 'You have already defined this value in <code>wp-config.php</code>, so it cannot be edited here.', 'bp-docs' ) ?><?php endif ?></p>
 
@@ -158,6 +159,7 @@ class BP_Docs_Admin {
 		$length = bp_docs_get_excerpt_length();
 
 		?>
+		<label for="bp-docs-excerpt-length" class="screen-reader-text"><?php _e( "Change the value for longer or shorter excerpts.", 'bp-docs' ) ?></label>
 		<input name="bp-docs-excerpt-length" id="bp-docs-excerpt-length" type="text" value="<?php echo esc_html( $length ) ?>" />
 		<p class="description"><?php _e( "Excerpts are shown on Docs directories, to provide better context. If your theme or language requires longer or shorter excerpts, change this value. Set to <code>0</code> to disable these excerpts.", 'bp-docs' ) ?></p>
 
@@ -168,6 +170,7 @@ class BP_Docs_Admin {
 		$name = bp_docs_get_group_tab_name();
 
 		?>
+		<label for="bp-docs-tab-name" class="screen-reader-text"><?php _e( "Change the word on groups' Docs tab.", 'bp-docs' ) ?></label>
 		<input name="bp-docs-tab-name" id="bp-docs-tab-name" type="text" value="<?php echo esc_html( $name ) ?>" />
 		<p class="description"><?php _e( "Change the word on the BuddyPress group tab from 'Docs' to whatever you'd like. Keep in mind that this will not change the text anywhere else on the page. For a more thorough text change, create a <a href='http://codex.buddypress.org/extending-buddypress/customizing-labels-messages-and-urls/'>language file</a> for BuddyPress Docs.", 'bp-docs' ) ?></p>
 
@@ -178,6 +181,7 @@ class BP_Docs_Admin {
 		$name = bp_docs_get_user_tab_name();
 
 		?>
+		<label for="bp-docs-user-tab-name" class="screen-reader-text"><?php _e( "Change the word on users' Docs tab.", 'bp-docs' ) ?></label>
 		<input name="bp-docs-user-tab-name" id="bp-docs-user-tab-name" type="text" value="<?php echo esc_html( $name ) ?>" />
 		<p class="description"><?php _e( "Change the word on users' Docs tabs from 'Docs' to whatever you'd like. Keep in mind that this will not change the text anywhere else on the page. For a more thorough text change, create a <a href='http://codex.buddypress.org/extending-buddypress/customizing-labels-messages-and-urls/'>language file</a> for BuddyPress Docs.", 'bp-docs' ) ?></p>
 
@@ -188,6 +192,7 @@ class BP_Docs_Admin {
 		$enabled = bp_docs_enable_attachments();
 
 		?>
+		<label for="bp-docs-enable-attachments" class="screen-reader-text"><?php _e( "Allow users to add attachments.", 'bp-docs' ) ?></label>
 		<select name="bp-docs-enable-attachments" id="bp-docs-enable-attachments">
 			<option value="yes" <?php selected( $enabled, true ) ?>><?php _e( 'Enabled', 'bp-docs' ) ?></option>
 			<option value="no" <?php selected( $enabled, false ) ?>><?php _e( 'Disabled', 'bp-docs' ) ?></option>

--- a/includes/attachments.php
+++ b/includes/attachments.php
@@ -581,7 +581,7 @@ class BP_Docs_Attachments {
 
 		<div id="docs-filter-section-attachments" class="docs-filter-section<?php if ( $has_attachment ) : ?> docs-filter-section-open<?php endif ?>">
 			<form method="get" action="<?php echo $form_action ?>">
-				<label for="docs-attachment-filter"><?php _e( 'Has attachment?', 'bp-docs' ) ?></label>
+				<label for="has-attachment"><?php _e( 'Has attachment?', 'bp-docs' ) ?></label>
 				<select id="has-attachment" name="has-attachment">
 					<option value="yes"<?php selected( $has_attachment, 'yes' ) ?>><?php _e( 'Yes', 'bp-docs' ) ?></option>
 					<option value="no"<?php selected( $has_attachment, 'no' ) ?>><?php _e( 'No', 'bp-docs' ) ?></option>

--- a/includes/css/bp-docs.css
+++ b/includes/css/bp-docs.css
@@ -714,3 +714,12 @@ table.diff {
 table#post-revisions {
 	margin-top: 20px;
 }
+
+/* Use for text meant only for screen readers */
+.screen-reader-text {
+	clip: rect(1px, 1px, 1px, 1px);
+	height: 1px;
+	overflow: hidden;
+	position: absolute !important;
+	width: 1px;
+}

--- a/includes/integration-groups.php
+++ b/includes/integration-groups.php
@@ -1230,11 +1230,11 @@ class BP_Docs_Group_Extension extends BP_Group_Extension {
 			<table class="group-docs-options">
 				<tr>
 					<td class="label">
-						<label for="bp-docs[can-create-admins]"><?php _e( 'Minimum role to associate Docs with this group:', 'bp-docs' ) ?></label>
+						<label for="bp-docs-can-create"><?php _e( 'Minimum role to associate Docs with this group:', 'bp-docs' ) ?></label>
 					</td>
 
 					<td>
-						<select name="bp-docs[can-create]">
+						<select name="bp-docs[can-create]" id="bp-docs-can-create">
 							<option value="admin" <?php selected( $can_create, 'admin' ) ?> /><?php _e( 'Group admin', 'bp-docs' ) ?></option>
 							<option value="mod" <?php selected( $can_create, 'mod' ) ?> /><?php _e( 'Group moderator', 'bp-docs' ) ?></option>
 							<option value="member" <?php selected( $can_create, 'member' ) ?> /><?php _e( 'Group member', 'bp-docs' ) ?></option>

--- a/includes/templates/docs/single/edit.php
+++ b/includes/templates/docs/single/edit.php
@@ -32,13 +32,13 @@
 	    </div>
 	    <div class="doc-content-wrapper">
 		<div id="doc-content-title">
-			<label for="doc[title]"><?php _e( 'Title', 'bp-docs' ) ?></label>
+			<label for="doc-title"><?php _e( 'Title', 'bp-docs' ) ?></label>
 			<input type="text" id="doc-title" name="doc[title]" class="long" value="<?php bp_docs_edit_doc_title() ?>" />
 		</div>
 
 		<?php if ( bp_docs_is_existing_doc() ) : ?>
 			<div id="doc-content-permalink">
-				<label for="doc[permalink]"><?php _e( 'Permalink', 'bp-docs' ) ?></label>
+				<label for="doc-permalink"><?php _e( 'Permalink', 'bp-docs' ) ?></label>
 				<code><?php echo trailingslashit( bp_get_root_domain() ) . bp_docs_get_docs_slug() . '/' ?></code><input type="text" id="doc-permalink" name="doc[permalink]" class="long" value="<?php bp_docs_edit_doc_slug() ?>" />
 			</div>
 		<?php endif ?>

--- a/includes/templatetags.php
+++ b/includes/templatetags.php
@@ -1132,11 +1132,11 @@ function bp_docs_access_options_helper( $settings_field, $doc_id = 0, $group_id 
 	?>
 	<tr class="bp-docs-access-row bp-docs-access-row-<?php echo esc_attr( $settings_field['name'] ) ?>">
 		<td class="desc-column">
-			<label for="settings[<?php echo esc_attr( $settings_field['name'] ) ?>]"><?php echo esc_html( $settings_field['label'] ) ?></label>
+			<label for="settings-<?php echo esc_attr( $settings_field['name'] ) ?>"><?php echo esc_html( $settings_field['label'] ) ?></label>
 		</td>
 
 		<td class="content-column">
-			<select name="settings[<?php echo esc_attr( $settings_field['name'] ) ?>]">
+			<select name="settings-<?php echo esc_attr( $settings_field['name'] ) ?>" id="settings-<?php echo esc_attr( $settings_field['name'] ) ?>">
 				<?php $access_options = bp_docs_get_access_options( $settings_field['name'], $doc_id, $group_id ) ?>
 				<?php foreach ( $access_options as $key => $option ) : ?>
 					<?php


### PR DESCRIPTION
This patch fixes the following screens:
* docs/create
* docs/mydoc/edit
* docs/mydoc/history
* BuddyPress Docs > Settings page

Fixes include:
* Associate the 'for' attribute of a label with the form element's 'id'
* Create 'id' for the form element where needed
* Add labels where needed
* Add screen reader text within labels where needed
* Add .screen-reader-text class to bp-docs.css

Note: This patch includes the new fixes for BuddyPress Docs > Settings screen (in includes/admin.php) and revisions per https://github.com/boonebgorges/buddypress-docs/pull/469.