### PR TITLE
fix resetting doc access settings on edit

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -457,6 +457,8 @@ function bp_docs_get_doc_settings( $doc_id = 0, $type = 'default' ) {
 		$saved_settings = array_filter( $saved_settings );
 
 		$doc_settings = wp_parse_args( $saved_settings, $default_settings );
+	} else {
+		$doc_settings = $saved_settings;
 	}
 
 	return apply_filters( 'bp_docs_get_doc_settings', $doc_settings, $doc_id, $default_settings );


### PR DESCRIPTION
Before this patch, the function `bpdv_refresh_access_settings` in `includes/js/edit-validation.js` would override custom saved access settings with the defaults in the edit screen. 