### PR TITLE
use groups_get_groupmeta to retrieve total_member_count

### DIFF
--- a/includes/templatetags.php
+++ b/includes/templatetags.php
@@ -864,7 +864,7 @@ function bp_docs_associated_group_summary( $group_id = 0 ) {
 				'width' => '40',
 				'height' => '40',
 			) );
-			$group_member_count = sprintf( 1 == $group->total_member_count ? __( '%s member', 'bp-docs' ) : __( '%s members', 'bp-docs' ), intval( $group->total_member_count ) );
+			$group_member_count = sprintf( 1 == groups_get_groupmeta( $group_id, $meta_key = 'total_member_count') ? __( '%s member', 'bp-docs' ) : __( '%s members', 'bp-docs' ), intval( groups_get_groupmeta( $group_id, $meta_key = 'total_member_count') ) );
 
 			switch ( $group->status ) {
 				case 'public' :


### PR DESCRIPTION
For some reason, "Associated Groups" would always return 0 members in my install. I didn't find much to suggest this is a bug affecting others, so YMMV. Nonetheless, I am able to get the stored value using `groups_get_groupmeta()` as opposed to `$group->total_member_count`. Let me know what you think.

### Before
![screen shot 2015-10-01 at 4 39 48 pm](https://cloud.githubusercontent.com/assets/600650/10250137/b4ac51b4-68ee-11e5-9fb3-166cb31d6315.png)

### After
![screen shot 2015-10-01 at 4 39 16 pm](https://cloud.githubusercontent.com/assets/600650/10250141/bd44abdc-68ee-11e5-974c-4f956f35b6ac.png)
 