### PR TITLE
Bugfix: Usage of undefined $comment in bp_docs_format_activity_action_bp_doc_comment()

### DIFF
--- a/includes/activity.php
+++ b/includes/activity.php
@@ -333,14 +333,13 @@ function bp_docs_format_activity_action_bp_doc_edited( $action, $activity ) {
  * @return string
  */
 function bp_docs_format_activity_action_bp_doc_comment( $action, $activity ) {
+	$comment = get_comment( $activity->secondary_item_id );
 	$doc = get_post( $comment->comment_post_ID );
-	if ( ! $doc ) {
+	if ( ! $doc || $doc->ID == 0 ) {
 		return $action;
 	}
 
 	$user_link = bp_core_get_userlink( $activity->user_id );
-
-	$comment = get_comment( $activity->secondary_item_id );
 	$doc_url = bp_docs_get_doc_link( $doc->ID );
 	$comment_url = $doc_url . '#comment-' . $comment->comment_ID;
 	$doc_link = sprintf( '<a href="%s">%s</a>', $comment_url, $doc->post_title );


### PR DESCRIPTION
Simple check for presence of `$doc` was not sufficient to catch this, as `get_post(null)` falls back (if set) to the global `$post`.