### PR TITLE
replace basename() with wp_basename()

### DIFF
--- a/includes/attachments.php
+++ b/includes/attachments.php
@@ -61,7 +61,7 @@ class BP_Docs_Attachments {
 	function catch_attachment_request() {
 		if ( ! empty( $_GET['bp-attachment'] ) ) {
 
-			$fn = basename( $_GET['bp-attachment'] );
+			$fn = wp_basename( $_GET['bp-attachment'] );
 
 			// Sanity check - don't do anything if this is not a Doc
 			if ( ! bp_docs_is_existing_doc() ) {

--- a/includes/integration-bp.php
+++ b/includes/integration-bp.php
@@ -9,4 +9,4 @@
  * @package BuddyPress_Docs
  */
 
-_deprecated_file( basename(__FILE__), '1.2', BP_DOCS_INCLUDES_PATH_ABS . 'component.php' );
+_deprecated_file( wp_basename(__FILE__), '1.2', BP_DOCS_INCLUDES_PATH_ABS . 'component.php' );

--- a/includes/templates/docs/comments.php
+++ b/includes/templates/docs/comments.php
@@ -5,6 +5,6 @@
  * @package BuddyPress_Docs
  */
 
-_deprecated_file( basename(__FILE__), '1.2', BP_DOCS_INCLUDES_PATH_ABS . 'templates/docs/single/comments.php' );
+_deprecated_file( wp_basename(__FILE__), '1.2', BP_DOCS_INCLUDES_PATH_ABS . 'templates/docs/single/comments.php' );
 require_once ( BP_DOCS_INCLUDES_PATH . 'templates/docs/single/comments.php');
 ?>

--- a/includes/templates/docs/edit-doc.php
+++ b/includes/templates/docs/edit-doc.php
@@ -5,6 +5,6 @@
  * @package BuddyPress_Docs
  */
 
-_deprecated_file( basename(__FILE__), '1.2', BP_DOCS_INCLUDES_PATH_ABS . 'templates/docs/single/edit.php' );
+_deprecated_file( wp_basename(__FILE__), '1.2', BP_DOCS_INCLUDES_PATH_ABS . 'templates/docs/single/edit.php' );
 require_once ( BP_DOCS_INCLUDES_PATH . 'templates/docs/single/edit.php');
 ?>

--- a/includes/templates/docs/history-doc.php
+++ b/includes/templates/docs/history-doc.php
@@ -5,6 +5,6 @@
  * @package BuddyPress_Docs
  */
 
-_deprecated_file( basename(__FILE__), '1.2', BP_DOCS_INCLUDES_PATH_ABS . 'templates/docs/single/history.php' );
+_deprecated_file( wp_basename(__FILE__), '1.2', BP_DOCS_INCLUDES_PATH_ABS . 'templates/docs/single/history.php' );
 require_once ( BP_DOCS_INCLUDES_PATH . '/templates/docs/single/history.php');
 ?>

--- a/includes/templates/docs/single-doc.php
+++ b/includes/templates/docs/single-doc.php
@@ -5,6 +5,6 @@
  * @package BuddyPress_Docs
  */
 
-_deprecated_file( basename(__FILE__), '1.2', BP_DOCS_INCLUDES_PATH_ABS . 'templates/docs/single/index.php' );
+_deprecated_file( wp_basename(__FILE__), '1.2', BP_DOCS_INCLUDES_PATH_ABS . 'templates/docs/single/index.php' );
 require_once ( BP_DOCS_INCLUDES_PATH . 'templates/docs/single/index.php');
 ?>

--- a/includes/templatetags.php
+++ b/includes/templatetags.php
@@ -2126,7 +2126,7 @@ function bp_docs_attachment_url( $attachment_id ) {
 
 		if ( bp_docs_attachment_protection() ) {
 			$attachment = get_post( $attachment_id );
-			$att_base   = basename( get_attached_file( $attachment_id ) );
+			$att_base   = wp_basename( get_attached_file( $attachment_id ) );
 			$doc_url    = bp_docs_get_doc_link( $attachment->post_parent );
 			$att_url    = add_query_arg( 'bp-attachment', $att_base, $doc_url );
 		} else {
@@ -2148,7 +2148,7 @@ function bp_docs_attachment_item_markup( $attachment_id, $format = 'full' ) {
 	$att_url    = bp_docs_get_attachment_url( $attachment_id );
 
 	$attachment = get_post( $attachment_id );
-	$att_base   = basename( get_attached_file( $attachment_id ) );
+	$att_base   = wp_basename( get_attached_file( $attachment_id ) );
 	$doc_url    = bp_docs_get_doc_link( $attachment->post_parent );
 
 	$attachment_ext = preg_replace( '/^.+?\.([^.]+)$/', '$1', $att_url );


### PR DESCRIPTION
replaced basename() with wp_basename(() calls for multibyte character path handling.
see https://core.trac.wordpress.org/ticket/21217