### PR TITLE
Adjust "bp_docs_create" cap calculation.

### DIFF
--- a/includes/caps.php
+++ b/includes/caps.php
@@ -42,8 +42,15 @@ function bp_docs_map_meta_caps( $caps, $cap, $user_id, $args ) {
 			if ( ! $user_id ) {
 				$caps[] = 'do_not_allow';
 
-			// All logged-in users can create
+			} else if ( $group_id = bp_get_current_group_id() ) {
+				// In a group, only set this cap if the user can associate a doc with the group.
+				if ( current_user_can( 'bp_docs_associate_with_group', $group_id ) ) {
+					$caps[] = 'exist';
+				} else {
+					$caps[] = 'do_not_allow';
+				}
 			} else {
+				// Otherwise, all logged-in users can create
 				$caps[] = 'exist';
 			}
 


### PR DESCRIPTION
Within a group, let the `bp_docs_create` capability mirror the `bp_docs_associate_with_group` capability for that specific user and group combination.

When answering a forum question (https://wordpress.org/support/topic/hide-create-new-doc-for-non-group-admins-moderators/) I figured that changing the "who can associate docs with this group" setting would hide the "create new docs" button within the group, and was surprised when it didn't. This fix seems to make sense to me, but maybe it's too sweeping (and would have unintended consequences), so I'm submitting it as a pull request.

Thanks! 