### PR TITLE
Cancel link improvement

### DIFF
--- a/includes/edit-lock.php
+++ b/includes/edit-lock.php
@@ -243,12 +243,19 @@ function bp_docs_cancel_edit_link() {
 
 		$doc_id = get_queried_object_id();
 
-		if ( !$doc_id )
-			return false;
+		if ( $doc_id ) {
+			$doc_permalink = bp_docs_get_doc_link( $doc_id );
 
-		$doc_permalink = bp_docs_get_doc_link( $doc_id );
-
-		$cancel_link = add_query_arg( 'bpd_action', 'cancel_edit', $doc_permalink );
+			$cancel_link = add_query_arg( 'bpd_action', 'cancel_edit', $doc_permalink );
+		} else {
+			// This is a cancel request on a new (or otherwise unknown) doc.
+			if ( $previous_page = wp_get_referer() ) {
+				$cancel_link = $previous_page;
+			} else {
+				$cancel_link = bp_docs_get_archive_link();
+			}
+			$doc_permalink = null;
+		}
 
 		return apply_filters( 'bp_docs_get_cancel_edit_link', $cancel_link, $doc_permalink );
 	}

--- a/includes/templates/docs/single/edit.php
+++ b/includes/templates/docs/single/edit.php
@@ -190,7 +190,7 @@ if ( ! $bp_docs_do_theme_compat ) : ?>
 			<?php wp_nonce_field( 'bp_docs_save' ) ?>
 
 			<input type="hidden" id="doc_id" name="doc_id" value="<?php echo $doc_id ?>" />
-			<input type="submit" name="doc-edit-submit" id="doc-edit-submit" value="<?php _e( 'Save', 'buddypress-docs' ) ?>"> <a href="<?php bp_docs_cancel_edit_link() ?>" class="action safe"><?php _e( 'Cancel', 'buddypress-docs' ); ?></a>
+			<input type="submit" name="doc-edit-submit" id="doc-edit-submit" value="<?php _e( 'Save', 'buddypress-docs' ) ?>"> <a href="<?php bp_docs_cancel_edit_link() ?>" class="action safe confirm"><?php _e( 'Cancel', 'buddypress-docs' ); ?></a>
 
 			<?php if ( bp_docs_is_existing_doc() ) : ?>
 				<?php if ( current_user_can( 'bp_docs_manage', $doc_id ) ) : ?>


### PR DESCRIPTION
Re: https://wordpress.org/support/topic/doc-create-page-cancel-button/

I do agree that the cancel button's behavior could be improved. This PR includes two commits: one that changes the cancel link to return the user to where she came from, another to add a "confirm" step when clicking cancel.