### PR TITLE
'Save and Continue Editing' button.

### DIFF
--- a/includes/component.php
+++ b/includes/component.php
@@ -381,7 +381,7 @@ class BP_Docs_Component extends BP_Component {
 	function catch_page_load() {
 		global $bp;
 
-		if ( !empty( $_POST['doc-edit-submit'] ) ) {
+		if ( ! empty( $_POST['doc-edit-submit'] ) || ! empty( $_POST['doc-edit-submit-continue'] ) ) {
 
 			// Existing Docs have a more specific permission check.
 			$doc = bp_docs_get_current_doc();

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1103,8 +1103,9 @@ function bp_docs_save_doc_via_post() {
 		'taxonomies'   => array(),
 		'settings'     => array(),
 		'parent_id'    => 0,
-		'save_context' => 'post_data'
-		);
+		'save_context' => 'post_data',
+		'redirect_to'  => 'single',
+	);
 
 	if ( isset( $_POST['doc_id'] ) && 0 != $_POST['doc_id'] ) {
 		$args['doc_id'] = (int) $_POST['doc_id'];
@@ -1143,6 +1144,8 @@ function bp_docs_save_doc_via_post() {
 
 	// Calculate parent_id only if hierarchy addon is active.
 	$args['parent_id'] = apply_filters( 'bp_docs_get_parent_id_via_post', $args['parent_id'] );
+
+	$args['redirect_to'] = isset( $_POST['doc-edit-submit-continue'] ) ? 'edit' : 'single';
 
 	$instance = new BP_Docs_Query;
 	return $instance->save( $args );

--- a/includes/query-builder.php
+++ b/includes/query-builder.php
@@ -439,6 +439,7 @@ class BP_Docs_Query {
 	 *                            'view_history' => 'creator' )
 	 *	      @type int    $parent_id    The ID of the parent doc, if applicable.
 	 *	      @type string $save_context How this doc is being saved.
+	 *	      @type string $redirect_to  Target mode to return to. 'single' or 'edit'.
 	 *        }
 	 * @return array {
 	 *		  @type string $message_type Type of message, success or error.
@@ -463,8 +464,9 @@ class BP_Docs_Query {
 			'taxonomies'	=> array(),
 			'settings'		=> array(),
 			'parent_id'		=> 0,
-			'save_context'  => 'direct'
-			);
+			'save_context'  => 'direct',
+			'redirect_to'   => 'single',
+		);
 
 		$args = wp_parse_args( $passed_args, $defaults );
 
@@ -588,7 +590,14 @@ class BP_Docs_Query {
 					// Existing Doc updated.
 					$result['message'] = __( 'Doc successfully edited!', 'bp-docs' );
 				}
-				$result['redirect'] = 'single';
+
+				if ( 'edit' === $args['redirect_to'] ) {
+					$result['redirect'] = 'edit';
+				} else {
+					$result['redirect'] = 'single';
+				}
+
+				$message_type = 'success';
 
 				// Save settings. We append the notice message if necessary.
 				$access_setting_message = bp_docs_save_doc_access_settings( $this->doc_id, $args['author_id'], $args['settings'], $this->is_new_doc );
@@ -615,7 +624,9 @@ class BP_Docs_Query {
 		 */
 		do_action( 'bp_docs_after_save', $this->doc_id, $args );
 
-		$message_type = $result['redirect'] == 'single' ? 'success' : 'error';
+		if ( ! isset( $message_type ) ) {
+			$message_type = $result['redirect'] == 'single' ? 'success' : 'error';
+		}
 
 		// Stuff data into a cookie so it can be accessed on next page load
 		if ( 'error' === $message_type ) {

--- a/includes/templates/docs/single/edit.php
+++ b/includes/templates/docs/single/edit.php
@@ -190,7 +190,7 @@ if ( ! $bp_docs_do_theme_compat ) : ?>
 			<?php wp_nonce_field( 'bp_docs_save' ) ?>
 
 			<input type="hidden" id="doc_id" name="doc_id" value="<?php echo $doc_id ?>" />
-			<input type="submit" name="doc-edit-submit" id="doc-edit-submit" value="<?php _e( 'Save', 'buddypress-docs' ) ?>"> <a href="<?php bp_docs_cancel_edit_link() ?>" class="action safe confirm"><?php _e( 'Cancel', 'buddypress-docs' ); ?></a>
+			<input type="submit" name="doc-edit-submit" id="doc-edit-submit" value="<?php _e( 'Save', 'buddypress-docs' ) ?>"> <input type="submit" name="doc-edit-submit-continue" id="doc-edit-submit-continue" value="<?php echo esc_attr( _e( 'Save and Continue Editing', 'buddypress-docs' ) ); ?>" /> <a href="<?php bp_docs_cancel_edit_link() ?>" class="action safe confirm"><?php _e( 'Cancel', 'buddypress-docs' ); ?></a>
 
 			<?php if ( bp_docs_is_existing_doc() ) : ?>
 				<?php if ( current_user_can( 'bp_docs_manage', $doc_id ) ) : ?>


### PR DESCRIPTION
See #67.

@dcavins Could you have a look at this? It clutters up the interface a tad but I think it's a valuable addition.

Also, please sign off on the new `redirect_to` param for the `save()` method. It's a bit clunky, but I couldn't think of a better way to do it without tearing the whole thing apart.