### PR TITLE
Remove html markup from gettext string.

### DIFF
--- a/includes/templates/docs/single/edit.php
+++ b/includes/templates/docs/single/edit.php
@@ -27,7 +27,7 @@ if ( ! $bp_docs_do_theme_compat ) : ?>
 	<div class="doc-content">
 
 	<div id="idle-warning" style="display:none">
-		<p><?php _e( 'You have been idle for <span id="idle-warning-time"></span>', 'buddypress-docs' ) ?></p>
+		<p><?php printf( __( 'You have been idle for %s', 'buddypress-docs' ), '<span id="idle-warning-time"></span>' ); ?></p>
 	</div>
 
 	<form action="" method="post" class="standard-form" id="doc-form">


### PR DESCRIPTION
This appears to be the root of the issue here: https://wordpress.org/support/topic/cant-create-document-since-update/#post-9787214

I think this is the right way to fix it, but would like a second opinion. :) 