### PR TITLE
Add Akismet filtering of doc content.

### DIFF
--- a/bp-docs.php
+++ b/bp-docs.php
@@ -391,6 +391,25 @@ class BP_Docs {
 		require_once( BP_DOCS_INCLUDES_PATH . 'addon-folders.php' );
 		$this->folders = new BP_Docs_Folders();
 
+		// Load Akismet support if Akismet is configured and desired.
+		/**
+		 * Should we apply Akismet filtration to BuddyPress Docs content?
+		 *
+		 * @since 2.1.0
+		 *
+		 * @param bool $use Whether we want to use Akismet for BP Docs.
+		 */
+		if ( apply_filters( 'bp_docs_use_akismet', true ) && defined( 'AKISMET_VERSION' ) && class_exists( 'Akismet' ) && ( ! empty( bp_get_option( 'wordpress_api_key' ) ) || defined( 'WPCOM_API_KEY' ) ) ) {
+			require_once( BP_DOCS_INCLUDES_PATH . 'addon-akismet.php' );
+			$this->akismet = new BP_Docs_Akismet();
+			$this->akismet->add_hooks();
+		}
+
+		// Load the Moderation addon.
+		require_once( BP_DOCS_INCLUDES_PATH . 'addon-moderation.php' );
+		$this->moderation = new BP_Docs_Moderation();
+		$this->moderation->add_hooks();
+
 		do_action( 'bp_docs_load_doc_extras' );
 	}
 
@@ -509,7 +528,7 @@ class BP_Docs {
 			$posts_query->is_404 = false;
 		}
 
-		// For single Doc views, allow access to 'deleted' items
+		// For single Doc views, allow access to 'deleted' or 'pending' items
 		// that the current user is the admin of
 		if ( $posts_query->is_single && bp_docs_get_post_type_name() === $posts_query->get( 'post_type' ) ) {
 
@@ -525,13 +544,13 @@ class BP_Docs {
 
 			// Post author or mod can visit it
 			if ( $author_id && ( $author_id == get_current_user_id() || current_user_can( 'bp_moderate' ) ) ) {
-				$posts_query->set( 'post_status', array( 'publish', 'trash' ) );
+				$posts_query->set( 'post_status', array( 'publish', 'trash', 'bp_docs_pending' ) );
 
 				// Make the 'trash' post status public
-				add_filter( 'posts_request', array( $this, 'make_trash_public' ) );
+				add_filter( 'posts_request', array( $this, 'make_post_statuses_public' ) );
 
 				// ... and undo that when we're done
-				add_filter( 'the_posts', array( $this, 'remove_make_trash_public' ) );
+				add_filter( 'the_posts', array( $this, 'remove_make_post_statuses_public' ) );
 			}
 		}
 	}
@@ -549,9 +568,10 @@ class BP_Docs {
 	 *
 	 * @param $request Passthrough.
 	 */
-	public function make_trash_public( $request ) {
+	public function make_post_statuses_public( $request ) {
 		global $wp_post_statuses;
 		$wp_post_statuses['trash']->public = true;
+		$wp_post_statuses['bp_docs_pending']->public = true;
 		return $request;
 	}
 
@@ -562,9 +582,10 @@ class BP_Docs {
 	 *
 	 * @param $posts Passthrough.
 	 */
-	public function remove_make_trash_public( $posts ) {
+	public function remove_make_post_statuses_public( $posts ) {
 		global $wp_post_statuses;
 		$wp_post_statuses['trash']->public = false;
+		$wp_post_statuses['bp_docs_pending']->public = false;
 		return $posts;
 	}
 

--- a/includes/activity.php
+++ b/includes/activity.php
@@ -155,6 +155,11 @@ function bp_docs_post_activity( $query ) {
 		return;
 	}
 
+	// Don't create activity if the post is not "publish" status.
+	if ( 'publish' != $doc->post_status ) {
+		return;
+	}
+
 	// Set the action. Filterable so that other integration pieces can alter it
 	$action 	= '';
 	$user_link 	= bp_core_get_userlink( $last_editor );
@@ -221,10 +226,13 @@ function bp_docs_delete_doc_activity( $new_status, $old_status, $post ) {
 		return;
 	}
 
-	if ( 'trash' != $new_status ) {
+	/*
+	 * Only continue the activity deletion process  
+	 * if the doc is being switched to a non-public status.
+	 */
+	if ( ! in_array( $new_status, array( 'trash', 'bp_docs_pending', 'draft' ) ) ) {
 		return;
 	}
-
 
 	$activities = bp_activity_get(
 		array(

--- a/includes/addon-akismet.php
+++ b/includes/addon-akismet.php
@@ -1,0 +1,185 @@
+<?php
+
+/**
+ * Scan doc content using the Akismet spam-filtering service.
+ *
+ * @since 2.1.0
+ */
+class BP_Docs_Akismet {
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 2.1.0
+	 */
+	public function __construct() {
+	}
+
+	/**
+	 * Add action and filter hooks to add Akismet functionality.
+	 *
+	 * @since 2.1.0
+	 */
+	public function add_hooks() {
+		// Check docs against the Akismet service.
+		add_filter( 'bp_docs_args_before_save', array( $this, 'check_for_spam'), 10, 3 );
+	}
+
+	/**
+	 * Check if the activity item is spam or ham.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @see http://akismet.com/development/api/
+	 * @todo Auto-delete old spam?
+	 *
+	 * @param array  $r    The parameters to be used in wp_insert_post().
+	 * @param object $this The BP_Docs_Query object.
+	 * @param array  $args The passed and filtered parameters for the doc
+	 *                     about to be saved.
+	 */
+	public function check_for_spam( $save_args, $bdq_object, $passed_args ) {
+		// Build data package for Akismet.
+		$akismet_package = $this->build_akismet_data_package( $save_args, $passed_args );
+
+		// Check with Akismet to see if this is spam.
+		$akismet_response = $this->send_akismet_request( $akismet_package, 'check', 'spam' );
+
+		// Spam.
+		if ( 'true' == $akismet_response['bp_docs_as_result'] ) {
+			/**
+			 * Fires after a doc has been proven to be spam, but before officially being marked as spam.
+			 *
+			 * @since 2.0.0
+			 *
+			 * @param array  $doc              The parameters to be used in wp_insert_post().
+			 * @param array  $akismet_response Array of activity data for item including
+			 *                                 Akismet check results data.
+			 * @param int    $author_id        The ID of the author who posted the spam.
+			 */
+			do_action( 'bp_docs_akismet_spam_caught', $save_args, $akismet_response, $passed_args['author_id'] );
+
+			// Set the post status as "pending" if it isn't already.
+			$save_args['post_status'] = 'bp_docs_pending';
+		}
+
+		return $save_args;
+	}
+
+	/**
+	 * Build a data package for the Akismet service to inspect.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @see http://akismet.com/development/api/#comment-check
+	 *
+	 * @param BP_Doc $activity Doc post data to be checked.
+	 * @param array  $args     Arguments calculated in the save() method.
+	 * @return array $package
+	 */
+	public function build_akismet_data_package( $doc_args, $args ) {
+		$userdata = get_userdata( $args['author_id'] );
+
+		$package = array(
+			'akismet_comment_nonce' => 'inactive',
+			'comment_author'        => $userdata->display_name,
+			'comment_author_email'  => $userdata->user_email,
+			'comment_author_url'    => bp_core_get_userlink( $userdata->ID, false, true),
+			'comment_content'       => $doc_args['post_content'],
+			'comment_type'          => 'bp_doc_created',
+			'permalink'             => site_url( bp_docs_get_docs_slug() ) . '/' . $doc_args['post_name'],
+			'user_ID'               => $userdata->ID,
+			'user_role'             => Akismet::get_user_roles( $userdata->ID ),
+		);
+
+		/**
+		 * Get the nonce if the new activity was submitted through the edit form.
+		 * This helps Akismet ensure that the update was a valid form submission.
+		 */
+		if ( ! empty( $_POST['_wpnonce'] ) ) {
+			$package['akismet_comment_nonce'] = wp_verify_nonce( $_POST['_wpnonce'], 'bp_docs_save' ) ? 'passed' : 'failed';
+		}
+
+		/**
+		 * Filters activity data before being sent to Akismet to inspect.
+		 *
+		 * @since 2.1.0
+		 *
+		 * @param array $package  Array of activity data for Akismet to inspect.
+		 * @param array $doc_args Doc data for doc about to be saved.
+		 */
+		return apply_filters( 'bp_docs_akismet_build_akismet_data_package', $package, $doc_args );
+	}
+
+	/**
+	 * Contact Akismet to check if this is spam or ham.
+	 *
+	 * This is based on the BuddyPress approach to passing
+	 * activity items to Akismet.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param array  $package  Packet of information to submit to Akismet.
+	 * @param string $check    "check" or "submit".
+	 * @param string $spam     "spam" or "ham".
+	 * @return array $activity_data Activity data, with Akismet data added.
+	 */
+	public function send_akismet_request( $package, $check = 'check', $spam = 'spam' ) {
+		$query_string = $path = '';
+
+		$package['blog']         = bp_get_option( 'home' );
+		$package['blog_charset'] = bp_get_option( 'blog_charset' );
+		$package['blog_lang']    = get_locale();
+		$package['referrer']     = $_SERVER['HTTP_REFERER'];
+		$package['user_agent']   = bp_core_current_user_ua();
+		$package['user_ip']      = bp_core_current_user_ip();
+
+		if ( Akismet::is_test_mode() ) {
+			$package['is_test'] = 'true';
+		}
+
+		// Keys to ignore.
+		$ignore = array( 'HTTP_COOKIE', 'HTTP_COOKIE2', 'HTTP_X_FORWARDED_FOR', 'HTTP_X_FORWARDED_HOST', 'HTTP_MAX_FORWARDS', 'HTTP_X_FORWARDED_SERVER', 'REDIRECT_STATUS', 'SERVER_PORT', 'PATH', 'PHP_AUTH_PW', 'DOCUMENT_ROOT', 'SERVER_ADMIN', 'QUERY_STRING', 'PHP_SELF', 'argv', 'argc', 'SCRIPT_FILENAME', 'SCRIPT_NAME' );
+		// Loop through _SERVER args and remove whitelisted keys.
+		foreach ( $_SERVER as $key => $value ) {
+			// Key should not be ignored.
+			if ( ! in_array( $key, $ignore ) && is_string( $value ) ) {
+				$package[$key] = $value;
+			}
+		}
+
+		if ( 'check' == $check ) {
+			$path = 'comment-check';
+		} elseif ( 'submit' == $check ) {
+			$path = 'submit-' . $spam;
+		}
+
+		// Send to Akismet.
+		add_filter( 'akismet_ua', array( $this, 'buddypress_docs_ua' ) );
+		$response = Akismet::http_post( http_build_query( $package ), $path );
+		remove_filter( 'akismet_ua', array( $this, 'buddypress_docs_ua' ) );
+
+		// Get the response.
+		if ( ! empty( $response[1] ) && ! is_wp_error( $response[1] ) ) {
+			$package['bp_docs_as_result'] = $response[1];
+		} else {
+			$package['bp_docs_as_result'] = false;
+		}
+
+		return $package;
+	}
+
+	/**
+	 * Filters user agent when sending to Akismet to add BuddyPress Docs info.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string $user_agent User agent string, as generated by Akismet.
+	 * @return string $user_agent Modified user agent string.
+	 */
+	public function buddypress_docs_ua( $user_agent ) {
+		// Prepend our application to the front
+		$user_agent = 'BuddyPress Docs/' . constant( 'BP_DOCS_VERSION' ) . ' | ' . $user_agent;
+		return $user_agent;
+	}
+}

--- a/includes/addon-akismet.php
+++ b/includes/addon-akismet.php
@@ -22,7 +22,7 @@ class BP_Docs_Akismet {
 	 */
 	public function add_hooks() {
 		// Check docs against the Akismet service.
-		add_filter( 'bp_docs_args_before_save', array( $this, 'check_for_spam'), 10, 3 );
+		add_filter( 'bp_docs_post_args_before_save', array( $this, 'check_for_spam'), 10, 3 );
 	}
 
 	/**
@@ -45,12 +45,15 @@ class BP_Docs_Akismet {
 		// Check with Akismet to see if this is spam.
 		$akismet_response = $this->send_akismet_request( $akismet_package, 'check', 'spam' );
 
-		// Spam.
-		if ( 'true' == $akismet_response['bp_docs_as_result'] ) {
+		/*
+		 * Spam.
+		 * Note that Akismet returns a true/false response as a string value.
+		 */
+		if ( 'true' === $akismet_response['bp_docs_as_result'] ) {
 			/**
-			 * Fires after a doc has been proven to be spam, but before officially being marked as spam.
+			 * Fires after a doc has been identified as spam, but before officially being marked as spam.
 			 *
-			 * @since 2.0.0
+			 * @since 2.1.0
 			 *
 			 * @param array  $doc              The parameters to be used in wp_insert_post().
 			 * @param array  $akismet_response Array of activity data for item including
@@ -135,7 +138,7 @@ class BP_Docs_Akismet {
 		$package['user_ip']      = bp_core_current_user_ip();
 
 		if ( Akismet::is_test_mode() ) {
-			$package['is_test'] = 'true';
+			$package['is_test'] = true;
 		}
 
 		// Keys to ignore.

--- a/includes/addon-moderation.php
+++ b/includes/addon-moderation.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Add a BP Docs-specific "pending" status to use in a moderation workflow.
+ *
+ * @since 2.1.0
+ */
+class BP_Docs_Moderation {
+
+	public $pending_status = 'bp_docs_pending';
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 2.1.0
+	 */
+	public function __construct() {
+	}
+
+	/**
+	 * Hook the Folders functionality into Docs.
+	 *
+	 * @since 2.1.0
+	 */
+	public function add_hooks() {
+		// Register a custom status that's a lot like the built-in "pending" status.
+		add_action( 'bp_docs_init', array( $this, 'register_docs_pending_status' ), 9 );
+
+		add_filter( 'display_post_states', array( $this, 'add_moderated_label' ), 10, 2 );
+	}
+
+	/**
+	 * Register custom status for pending BP Docs.
+	 *
+	 * @since 2.1.0
+	 */
+	public function register_docs_pending_status() {
+		$args = array(
+			'label'                     => _x( 'Awaiting Moderation', 'Status General Name', 'buddypress-docs' ),
+			'label_count'               => _n_noop( 'Awaiting Moderation (%s)',  'Pending (%s)', 'buddypress-docs' ),
+			'public'                    => current_user_can( 'bp_moderate' ),
+			'show_in_admin_all_list'    => true,
+			'show_in_admin_status_list' => true,
+			'exclude_from_search'       => true,
+		);
+		register_post_status( $this->pending_status, $args );
+	}
+
+	/**
+	 * In the BP Docs list in wp-admin, add a label to posts that require moderation.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param array   $post_states An array of post display states.
+	 * @param WP_Post $post        The current post object.
+	 */
+	function add_moderated_label( $post_states, $post ) {
+		if ( $this->pending_status == $post->post_status ) {
+			$post_states[] = __( 'Awaiting Moderation', 'buddypress-docs' );
+		}
+		return $post_states;
+	}
+}

--- a/includes/addon-moderation.php
+++ b/includes/addon-moderation.php
@@ -18,13 +18,13 @@ class BP_Docs_Moderation {
 	}
 
 	/**
-	 * Hook the Folders functionality into Docs.
+	 * Add hooks for moderation functionality.
 	 *
 	 * @since 2.1.0
 	 */
 	public function add_hooks() {
 		// Register a custom status that's a lot like the built-in "pending" status.
-		add_action( 'bp_docs_init', array( $this, 'register_docs_pending_status' ), 9 );
+		add_action( 'bp_docs_init', array( $this, 'register_docs_pending_status' ) );
 
 		add_filter( 'display_post_states', array( $this, 'add_moderated_label' ), 10, 2 );
 	}
@@ -36,8 +36,8 @@ class BP_Docs_Moderation {
 	 */
 	public function register_docs_pending_status() {
 		$args = array(
-			'label'                     => _x( 'Awaiting Moderation', 'Status General Name', 'buddypress-docs' ),
-			'label_count'               => _n_noop( 'Awaiting Moderation (%s)',  'Pending (%s)', 'buddypress-docs' ),
+			'label'                     => _x( 'Awaiting Moderation', 'General name of pending doc status', 'buddypress-docs' ),
+			'label_count'               => _n_noop( 'Awaiting Moderation (%s)',  'Awaiting Moderation (%s)', 'buddypress-docs' ),
 			'public'                    => current_user_can( 'bp_moderate' ),
 			'show_in_admin_all_list'    => true,
 			'show_in_admin_status_list' => true,

--- a/includes/component.php
+++ b/includes/component.php
@@ -767,7 +767,7 @@ class BP_Docs_Component extends BP_Component {
 	 * @return str $link The filtered permalink
 	 */
 	function filter_permalinks( $link, $post, $leavename, $sample ) {
-		if ( bp_docs_get_post_type_name() == $post->post_type && ! empty( $post->post_name ) ) {
+		if ( bp_docs_get_post_type_name() == $post->post_type ) {
 			$link = trailingslashit( bp_docs_get_archive_link() . $post->post_name );
 		}
 

--- a/includes/component.php
+++ b/includes/component.php
@@ -767,7 +767,7 @@ class BP_Docs_Component extends BP_Component {
 	 * @return str $link The filtered permalink
 	 */
 	function filter_permalinks( $link, $post, $leavename, $sample ) {
-		if ( bp_docs_get_post_type_name() == $post->post_type ) {
+		if ( bp_docs_get_post_type_name() == $post->post_type && ! empty( $post->post_name ) ) {
 			$link = trailingslashit( bp_docs_get_archive_link() . $post->post_name );
 		}
 

--- a/includes/integration-users.php
+++ b/includes/integration-users.php
@@ -181,7 +181,7 @@ class BP_Docs_Users_Integration {
 			$query_args['post_status'] = array( 'publish' );
 		} else if ( bp_docs_is_started_by() ) {
 			$query_args['author'] = bp_displayed_user_id();
-			$query_args['post_status'] = array( 'publish', 'trash' );
+			$query_args['post_status'] = array( 'publish', 'trash', 'bp_docs_pending' );
 		} else {
 			// Just in case
 			$query_args['post__in'] = array( 0 );

--- a/includes/query-builder.php
+++ b/includes/query-builder.php
@@ -557,7 +557,7 @@ class BP_Docs_Query {
 			 * @param array  $args The passed and filtered parameters for the doc
 			 *                     about to be saved.
 			 */
-			$r = apply_filters( 'bp_docs_args_before_save', $r, $this, $args );
+			$r = apply_filters( 'bp_docs_post_args_before_save', $r, $this, $args );
 
 			// Insert or update the post.
 			$this->doc_id = wp_insert_post( $r );

--- a/includes/query-builder.php
+++ b/includes/query-builder.php
@@ -236,10 +236,10 @@ class BP_Docs_Query {
 				$wp_query_args['author'] = implode( ',', wp_parse_id_list( $this->query_args['author_id'] ) );
 			}
 
-			// If this is the user's "started by me" library, we'll include trashed posts
+			// If this is the user's "started by me" library, we'll include trashed and pending posts
 			// Any edit to a trashed post restores it to status 'publish'
 			if ( ! empty( $this->query_args['author_id'] ) && $this->query_args['author_id'] == get_current_user_id()  ) {
-				$wp_query_args['post_status'] = array( 'publish', 'trash' );
+				$wp_query_args['post_status'] = array( 'publish', 'trash', 'bp_docs_pending' );
 			}
 
 			// If an edited_by_id param has been passed, get a set
@@ -500,8 +500,8 @@ class BP_Docs_Query {
 		 *
 		 * @since 2.0.0
 		 *
-		 * @param array $args The default results array.
-		 * @param array $args The parameters for the doc about to be saved.
+		 * @param array $result The default results array.
+		 * @param array $args   The parameters for the doc about to be saved.
 		 */
 		$result = apply_filters( 'bp_docs_filter_result_before_save', $result, $args );
 
@@ -541,7 +541,23 @@ class BP_Docs_Query {
 			} else {
 				// Save pre-update post data, for comparison by callbacks.
 				$this->previous_revision = get_post( $args['doc_id'] );
+				// If this post is "pending," leave it pending.
+				if ( $this->previous_revision->post_status === 'bp_docs_pending' ) {
+					$r['post_status'] = 'bp_docs_pending';
+				}
 			}
+
+			/**
+			 * Fires before the doc has been saved.
+			 *
+			 * @since 2.1.0
+			 *
+			 * @param array  $r    The parameters to be used in wp_insert_post().
+			 * @param object $this The BP_Docs_Query object.
+			 * @param array  $args The passed and filtered parameters for the doc
+			 *                     about to be saved.
+			 */
+			$r = apply_filters( 'bp_docs_args_before_save', $r, $this, $args );
 
 			// Insert or update the post.
 			$this->doc_id = wp_insert_post( $r );

--- a/includes/templatetags.php
+++ b/includes/templatetags.php
@@ -2318,8 +2318,11 @@ function bp_docs_get_container_class() {
 function bp_docs_doc_row_classes() {
 	$classes = array();
 
-	if ( get_post_status( get_the_ID() ) == 'trash' ) {
+	$status = get_post_status( get_the_ID() );
+	if ( 'trash' == $status ) {
 		$classes[] = 'bp-doc-trashed-doc';
+	} elseif ( 'bp_docs_pending' == $status ) {
+		$classes[] = 'bp-doc-pending-doc';
 	}
 
 	// Pass the classes out as an array for easy unsetting or adding new elements
@@ -2337,8 +2340,11 @@ function bp_docs_doc_row_classes() {
  * @since 1.5.5
  */
 function bp_docs_doc_trash_notice() {
-	if ( get_post_status( get_the_ID() ) == 'trash' ) {
+	$status = get_post_status( get_the_ID() );
+	if ( 'trash' == $status ) {
 		echo ' <span title="' . __( 'This Doc is in the Trash', 'buddypress-docs' ) . '" class="bp-docs-trashed-doc-notice">' . __( 'Trash', 'buddypress-docs' ) . '</span>';
+	} elseif ( 'bp_docs_pending' == $status  ) {
+		echo ' <span title="' . __( 'This Doc is awaiting moderation', 'buddypress-docs' ) . '" class="bp-docs-pending-doc-notice">' . __( 'Awaiting Moderation', 'buddypress-docs' ) . '</span>';
 	}
 }
 


### PR DESCRIPTION
If Akismet is configured for the site, send the content over to Akismet for inspection. If Akismet responds that the content looks like spam, set the post status to a new status, "bp_docs_pending," so that site admins can choose to either publish or delete the new content. Docs that are pending are visible to the creator and site admins only.