### PR TITLE
Add context parameter to bp_docs_toggleable_open_or_closed_class().

### DIFF
--- a/includes/addon-folders.php
+++ b/includes/addon-folders.php
@@ -1877,7 +1877,7 @@ function bp_docs_folders_meta_box() {
 	?>
 
 	<div id="doc-folders" class="doc-meta-box">
-		<div class="toggleable <?php bp_docs_toggleable_open_or_closed_class() ?>">
+		<div class="toggleable <?php bp_docs_toggleable_open_or_closed_class( 'folders-meta-box' ) ?>">
 			<p id="folders-toggle-edit" class="toggle-switch">
 				<span class="hide-if-js toggle-link-no-js"><?php _e( 'Folders', 'buddypress-docs' ) ?></span>
 				<a class="hide-if-no-js toggle-link" id="folders-toggle-link" href="#"><span class="show-pane plus-or-minus"></span><span class="toggle-title"><?php _e( 'Folders', 'buddypress-docs' ) ?></span></a>

--- a/includes/templates/docs/docs-folder-loop.php
+++ b/includes/templates/docs/docs-folder-loop.php
@@ -16,7 +16,7 @@
 				<?php endif ?>
 
 				<td class="folder-row-name" colspan=10>
-					<div class="toggleable <?php bp_docs_toggleable_open_or_closed_class(); ?>">
+					<div class="toggleable <?php bp_docs_toggleable_open_or_closed_class( 'folder-contents-toggle' ); ?>">
 						<span class="folder-toggle-link toggle-link-js"><a class="toggle-folder" id="expand-folder-<?php echo $folder->ID; ?>" data-folder-id="<?php echo $folder->ID; ?>" href="<?php echo esc_url( bp_docs_get_folder_url( $folder->ID ) ) ?>"><span class="hide-if-no-js"><?php bp_docs_genericon( 'expand', $folder->ID ); ?></span><?php bp_docs_genericon( 'category', $folder->ID ); ?><?php echo esc_html( $folder->post_title ) ?></a></span>
 						<div class="toggle-content folder-loop"></div>
 					</div>

--- a/includes/templates/docs/docs-loop.php
+++ b/includes/templates/docs/docs-loop.php
@@ -95,7 +95,7 @@ if ( ! $bp_docs_do_theme_compat ) : ?>
 					<?php endif ?>
 
 					<td class="folder-row-name" colspan=10>
-						<div class="toggleable <?php bp_docs_toggleable_open_or_closed_class(); ?>">
+						<div class="toggleable <?php bp_docs_toggleable_open_or_closed_class( 'folder-contents-toggle' ); ?>">
 							<span class="folder-toggle-link toggle-link-js"><a class="toggle-folder" id="expand-folder-<?php echo $folder->ID; ?>" data-folder-id="<?php echo $folder->ID; ?>" href="<?php echo esc_url( bp_docs_get_folder_url( $folder->ID ) ) ?>"><span class="hide-if-no-js"><?php bp_docs_genericon( 'expand', $folder->ID ); ?></span><?php bp_docs_genericon( 'category', $folder->ID ); ?><?php echo esc_html( $folder->post_title ) ?></a></span>
 							<div class="toggle-content folder-loop"></div>
 						</div>

--- a/includes/templates/docs/single/edit.php
+++ b/includes/templates/docs/single/edit.php
@@ -80,7 +80,7 @@ if ( ! $bp_docs_do_theme_compat ) : ?>
 				<?php do_action( 'bp_docs_before_assoc_groups_meta_box', $doc_id ); ?>
 
 				<div id="doc-associated-group" class="doc-meta-box">
-					<div class="toggleable <?php bp_docs_toggleable_open_or_closed_class() ?>">
+					<div class="toggleable <?php bp_docs_toggleable_open_or_closed_class( 'associated-group-meta-box' ) ?>">
 						<p class="toggle-switch" id="associated-group-toggle">
 							<span class="hide-if-js toggle-link-no-js"><?php _e( 'Associated Group', 'buddypress-docs' ) ?></span>
 							<a class="hide-if-no-js toggle-link" id="associated-toggle-link" href="#"><span class="show-pane plus-or-minus"></span><?php _e( 'Associated Group', 'buddypress-docs' ) ?></a>
@@ -101,7 +101,7 @@ if ( ! $bp_docs_do_theme_compat ) : ?>
 				<?php do_action( 'bp_docs_before_access_settings_meta_box', $doc_id ) ?>
 
 				<div id="doc-settings" class="doc-meta-box">
-					<div class="toggleable <?php bp_docs_toggleable_open_or_closed_class() ?>">
+					<div class="toggleable <?php bp_docs_toggleable_open_or_closed_class( 'access-meta-box' ) ?>">
 						<p class="toggle-switch" id="settings-toggle">
 							<span class="hide-if-js toggle-link-no-js"><?php _e( 'Access', 'buddypress-docs' ) ?></span>
 							<a class="hide-if-no-js toggle-link" id="settings-toggle-link" href="#"><span class="show-pane plus-or-minus"></span><?php _e( 'Access', 'buddypress-docs' ) ?></a>
@@ -121,7 +121,7 @@ if ( ! $bp_docs_do_theme_compat ) : ?>
 			<?php do_action( 'bp_docs_before_tags_meta_box', $doc_id ) ?>
 
 			<div id="doc-tax" class="doc-meta-box">
-				<div class="toggleable <?php bp_docs_toggleable_open_or_closed_class() ?>">
+				<div class="toggleable <?php bp_docs_toggleable_open_or_closed_class( 'tags-meta-box' ) ?>">
 					<p id="tags-toggle-edit" class="toggle-switch">
 						<span class="hide-if-js toggle-link-no-js"><?php _e( 'Tags', 'buddypress-docs' ) ?></span>
 						<a class="hide-if-no-js toggle-link" id="tags-toggle-link" href="#"><span class="show-pane plus-or-minus"></span><?php _e( 'Tags', 'buddypress-docs' ) ?></a>
@@ -150,7 +150,7 @@ if ( ! $bp_docs_do_theme_compat ) : ?>
 				<?php do_action( 'bp_docs_before_parent_meta_box', $doc_id ) ?>
 
 				<div id="doc-parent" class="doc-meta-box">
-					<div class="toggleable <?php bp_docs_toggleable_open_or_closed_class() ?>">
+					<div class="toggleable <?php bp_docs_toggleable_open_or_closed_class( 'parent-meta-box' ) ?>">
 						<p class="toggle-switch" id="parent-toggle">
 							<span class="hide-if-js toggle-link-no-js"><?php _e( 'Parent', 'buddypress-docs' ) ?></span>
 							<a class="hide-if-no-js toggle-link" id="parent-toggle-link" href="#"><span class="show-pane plus-or-minus"></span><?php _e( 'Parent', 'buddypress-docs' ) ?></a>

--- a/includes/templatetags.php
+++ b/includes/templatetags.php
@@ -2370,8 +2370,9 @@ function bp_docs_is_doc_trashed( $doc_id = false ) {
  * Output 'toggle-open' or 'toggle-closed' class for toggleable div.
  *
  * @since 1.8
+ * @since 2.1 Added $context parameter
  */
-function bp_docs_toggleable_open_or_closed_class() {
+function bp_docs_toggleable_open_or_closed_class( $context = 'unknown' ) {
 	if ( bp_docs_is_doc_create() ) {
 		$class = 'toggle-open';
 	} else {
@@ -2383,9 +2384,10 @@ function bp_docs_toggleable_open_or_closed_class() {
 	 *
 	 * @since 2.1.0
 	 *
-	 * @param string $class 'toggle-open' or 'toggle-closed'.
+	 * @param string $class   'toggle-open' or 'toggle-closed'.
+	 * @param string $context In what context is this function being called.
 	 */
-	echo esc_attr( apply_filters( 'bp_docs_toggleable_open_or_closed_class', $class ) );
+	echo esc_attr( apply_filters( 'bp_docs_toggleable_open_or_closed_class', $class, $context ) );
 }
 
 /**


### PR DESCRIPTION
Add a context argument that is passed to the `bp_docs_toggleable_open_or_closed_class` filter, helping the dev to know which situation is being calculated. This is useful if you want one of the meta boxes to be closed by default on the edit screen, for instance.