### PR TITLE
Had an issue where empty $cached array was returned. this fixed it.

### DIFF
--- a/includes/templatetags.php
+++ b/includes/templatetags.php
@@ -2085,7 +2085,7 @@ function bp_docs_get_doc_attachments( $doc_id = null ) {
 
 	$cache_key = 'bp_docs_attachments:' . $doc_id;
 	$cached = wp_cache_get( $cache_key, 'bp_docs_nonpersistent' );
-	if ( false !== $cached ) {
+	if (count($cached) > 0 ) {
 		return $cached;
 	}
 


### PR DESCRIPTION

Docs attachment were not showing in some cases. Investigated it and realized, that event empty $cached arrays were returned. This is now working for me. 