### PR TITLE
Improve scalability of permissions check

### DIFF
--- a/includes/access-query.php
+++ b/includes/access-query.php
@@ -134,7 +134,7 @@ class BP_Docs_Access_Query {
 	 *
 	 * @since 1.2.8
 	 */
-	public function get_doc_ids() {
+	public function get_doc_ids($id = false) {
 		// Check the cache first.
 		$last_changed = wp_cache_get( 'last_changed', 'bp_docs_nonpersistent' );
 		if ( false === $last_changed ) {
@@ -158,7 +158,8 @@ class BP_Docs_Access_Query {
 			if ( empty( $tax_query ) ) {
 				$protected_doc_ids = array( 0 );
 			} else {
-				$forbidden_fruit = new WP_Query( array(
+
+				$query_args = array(
 					'post_type' => bp_docs_get_post_type_name(),
 					'posts_per_page' => -1,
 					'nopaging' => true,
@@ -167,7 +168,14 @@ class BP_Docs_Access_Query {
 					'update_post_meta_cache' => false,
 					'no_found_rows' => 1,
 					'fields' => 'ids',
-				) );
+				);
+
+				if ( is_int( $id ) ) {
+					$query_args['post__in'] = array( $id );
+				}
+
+				$forbidden_fruit = new WP_Query( $query_args );
+
 				if ( $forbidden_fruit->posts ) {
 					$protected_doc_ids = $forbidden_fruit->posts;
 				} else {
@@ -175,7 +183,7 @@ class BP_Docs_Access_Query {
 					 * If no results are returned, we save a 0 value to avoid the
 					 * post__in => array() fetches everything problem.
 					 */
-				 	$protected_doc_ids = array( 0 );
+					$protected_doc_ids = array( 0 );
 				}
 			}
 
@@ -218,15 +226,15 @@ class BP_Docs_Access_Query {
 				$restricted_comment_doc_ids = array( 0 );
 			} else {
 				$forbidden_fruit = new WP_Query( array(
-					'post_type' => bp_docs_get_post_type_name(),
-					'posts_per_page' => -1,
-					'nopaging' => true,
-					'tax_query' => $tax_query,
-					'update_post_term_cache' => false,
-					'update_post_meta_cache' => false,
-					'no_found_rows' => 1,
-					'fields' => 'ids',
-				) );
+					                                 'post_type' => bp_docs_get_post_type_name(),
+					                                 'posts_per_page' => -1,
+					                                 'nopaging' => true,
+					                                 'tax_query' => $tax_query,
+					                                 'update_post_term_cache' => false,
+					                                 'update_post_meta_cache' => false,
+					                                 'no_found_rows' => 1,
+					                                 'fields' => 'ids',
+				                                 ) );
 				if ( $forbidden_fruit->posts ) {
 					$restricted_comment_doc_ids = $forbidden_fruit->posts;
 				} else {
@@ -234,7 +242,7 @@ class BP_Docs_Access_Query {
 					 * If no results are returned, we save a 0 value to avoid the
 					 * post__in => array() fetches everything problem.
 					 */
-				 	$restricted_comment_doc_ids = array( 0 );
+					$restricted_comment_doc_ids = array( 0 );
 				}
 			}
 

--- a/includes/activity.php
+++ b/includes/activity.php
@@ -556,7 +556,7 @@ function bp_docs_allow_activity_item_visibility( $allow, $activity_obj, $user_id
 		case 'bp_doc_created':
 		case 'bp_doc_edited':
 			$bp_docs_access_query = BP_Docs_Access_Query::init( $user_id );
-			$protected_doc_ids    = $bp_docs_access_query->get_doc_ids();
+			$protected_doc_ids    = $bp_docs_access_query->get_doc_ids($activity_obj->secondary_item_id);
 
 			// For bp_doc_created and bp_doc_edited, the secondary_item_id is the doc_id.
 			if ( in_array( $activity_obj->secondary_item_id, $protected_doc_ids ) ) {


### PR DESCRIPTION
Improve scalability of permissions check by only retrieving relative IDs as opposed to the ID of all posts.

Currently the permissions check runs a query to retrieve all IDs to check for appropriate permissions. This allows for the ability to only return the current ID if it is in the list. On large sites this prevents resource errors that can otherwise occur on installs with 10,000+ documents.

Note I'm really not sure of where the best branch for this is and I'm fully open to moving or any other changes.