### PR TITLE
Save return of bp_get_option locally before calling empty()

### DIFF
--- a/bp-docs.php
+++ b/bp-docs.php
@@ -399,10 +399,13 @@ class BP_Docs {
 		 *
 		 * @param bool $use Whether we want to use Akismet for BP Docs.
 		 */
-		if ( apply_filters( 'bp_docs_use_akismet', true ) && defined( 'AKISMET_VERSION' ) && class_exists( 'Akismet' ) && ( ! empty( bp_get_option( 'wordpress_api_key' ) ) || defined( 'WPCOM_API_KEY' ) ) ) {
-			require_once( BP_DOCS_INCLUDES_PATH . 'addon-akismet.php' );
-			$this->akismet = new BP_Docs_Akismet();
-			$this->akismet->add_hooks();
+		if ( apply_filters( 'bp_docs_use_akismet', true ) && defined( 'AKISMET_VERSION' ) && class_exists( 'Akismet' ) ) {
+			$wordpress_api_key = bp_get_option( 'wordpress_api_key' );
+			if ( ! empty( $wordpress_api_key ) || defined( 'WPCOM_API_KEY' ) ) {
+				require_once( BP_DOCS_INCLUDES_PATH . 'addon-akismet.php' );
+				$this->akismet = new BP_Docs_Akismet();
+				$this->akismet->add_hooks();
+			}
 		}
 
 		// Load the Moderation addon.


### PR DESCRIPTION
PHP 5.5 added the functionality to use empty() directly on the return values of functions. Eliminating that by saving the return value to a local variable before calling empty() restores compatibility with PHP 5.3 and 5.4, which are still officially supported by Buddypress and Wordpress.