### PR TITLE
Enable anyone to comment when permissions allow

### DIFF
--- a/includes/caps.php
+++ b/includes/caps.php
@@ -52,7 +52,6 @@ function bp_docs_map_meta_caps( $caps, $cap, $user_id, $args ) {
 		// Special cases: logged-in users only.
 		case 'bp_docs_edit' :
 		case 'bp_docs_manage' :
-		case 'bp_docs_post_comments' :
 			if ( ! $user_id ) {
 				return array( 'do_not_allow' );
 			}
@@ -62,6 +61,7 @@ function bp_docs_map_meta_caps( $caps, $cap, $user_id, $args ) {
 		case 'bp_docs_read' :
 		case 'bp_docs_view_history' :
 		case 'bp_docs_read_comments' :
+		case 'bp_docs_post_comments' :
 			// Reset all caps. We bake from scratch
 			$caps = array();
 

--- a/tests/test-permissions.php
+++ b/tests/test-permissions.php
@@ -668,7 +668,7 @@ class BP_Docs_Tests_Permissions extends BP_Docs_TestCase {
 		update_post_meta( $d, 'bp_docs_settings', $doc_settings );
 
 		$this->set_current_user( 0 );
-		$this->assertFalse( current_user_can( 'bp_docs_post_comments', $d ) );
+		$this->assertTrue( current_user_can( 'bp_docs_post_comments', $d ) );
 
 		$u = $this->factory->user->create();
 		$this->set_current_user( $u );


### PR DESCRIPTION
Unless I am misunderstanding something, at present it does not seem possible for logged-out users to comment on a Doc regardless of its access settings. This PR moves the `bp_docs_post_comments` capability check out of the "Special Cases" section since the ability for logged-out users to comment on a Doc is presumably desired behaviour.