### PR TITLE
Improve access-related redirects for logged-in users.

### DIFF
--- a/bp-docs.php
+++ b/bp-docs.php
@@ -613,13 +613,20 @@ class BP_Docs {
 			return;
 		}
 
-		if ( ! current_user_can( $action ) ) {
+		if ( current_user_can( $action ) ) {
+			return;
+		}
+
+		if ( ! is_user_logged_in() ) {
 			$redirect_to = bp_docs_get_doc_link();
 
 			bp_core_no_access( array(
 				'mode' => 2,
 				'redirect' => $redirect_to,
 			) );
+		} else {
+			bp_core_add_message( __( 'You do not have permission to do that.', 'buddypress-docs' ), 'error' );
+			bp_core_redirect( bp_get_root_domain() );
 		}
 	}
 


### PR DESCRIPTION
Since https://buddypress.trac.wordpress.org/changeset/11610, logged-in
visitors to wp-login.php are redirected by BuddyPress to the URL indicated
by the `redirect_to` parameter. This change conflicts with Docs's behavior,
which is to send non-authorized (but authenticated) users to wp-login.php.
The current change works around this problem by sending logged-in users
to the home page instead.