### PR TITLE
Use `WP_Query` when fetching doc attachments.

### DIFF
--- a/includes/templatetags.php
+++ b/includes/templatetags.php
@@ -2120,10 +2120,11 @@ function bp_docs_get_doc_attachments( $doc_id = null ) {
 		'update_post_meta_cache' => true,
 		'update_post_term_cache' => false,
 		'posts_per_page' => -1,
+		'post_status' => 'inherit',
 	), $doc_id );
 
-	$atts = get_posts( $atts_args );
-	$atts = apply_filters( 'bp_docs_get_doc_attachments', $atts, $doc_id );
+	$atts_query = new WP_Query( $atts_args );
+	$atts = apply_filters( 'bp_docs_get_doc_attachments', $atts_query->posts, $doc_id );
 
 	wp_cache_set( $cache_key, $atts, 'bp_docs_nonpersistent' );
 

--- a/includes/templatetags.php
+++ b/includes/templatetags.php
@@ -151,11 +151,12 @@ function bp_docs_has_docs( $args = array() ) {
 					'post_parent__in' => $doc_ids,
 					'update_post_term_cache' => false,
 					'posts_per_page' => -1,
+					'post_status' => 'inherit'
 				), $doc_ids );
 
-				$attachments = get_posts( $attachment_args );
+				$atts_query = new WP_Query( $attachment_args );
 
-				foreach ( $attachments as $a ) {
+				foreach ( $atts_query->posts as $a ) {
 					$att_hash[ $a->post_parent ][] = $a;
 				}
 


### PR DESCRIPTION
Plugins that filter parts of `WP_Query` to modify results - such as WPML - are stymied by the fact that we use `get_posts()` (with `suppress_filters=true`) instead of a direct `WP_Query`.

We could switch to using `WP_Query`, as in this PR. It's likely to have side effects. IMO it seems like the unwanted side effects of *using* `WP_Query` are fewer (and easier to predict, and easier to fix) than the side effects of *not* doing so. But @dcavins , would love your second opinion.