### PR TITLE
Add shortcode to output a simple BP Docs list.

### DIFF
--- a/bp-docs.php
+++ b/bp-docs.php
@@ -142,6 +142,9 @@ class BP_Docs {
 		// class-wp-widget-recent-docs.php adds a widget to show recently created docs.
 		require( BP_DOCS_INCLUDES_PATH . 'class-wp-widget-recent-docs.php' );
 
+		// class-wp-widget-recent-docs.php adds a widget to show recently created docs.
+		require( BP_DOCS_INCLUDES_PATH . 'shortcode.php' );
+
 		// Dashboard-specific functions
 		if ( is_admin() ) {
 			require( BP_DOCS_INCLUDES_PATH . 'admin.php' );

--- a/includes/shortcode.php
+++ b/includes/shortcode.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Shortcode for outputting recent docs, similar to the Recent Docs Widget,
+ * but as a shortcode.
+ *
+ * @package BuddyPressDocs
+ * @since 2.3
+ */
+
+function bp_docs_recent_docs_shortcode_handler( $atts ) {
+    $a = shortcode_atts( array(
+        'number'        => 5,
+        'show_date'     => false,
+        'author_id'     => null,
+        'group_id'      => null,
+        'folder_id'     => null,
+        'context_aware' => false,
+    ), $atts );
+
+	$doc_args = array(
+		'posts_per_page' => $a['number'],
+		'post_status'    => array( 'publish' ),
+		'author_id'      => $a['author_id'],
+		'group_id'       => $a['group_id'],
+		'folder_id'      => $a['folder_id'],
+	);
+
+	/**
+	 * Limit to docs associated with the current context
+	 * if the shortcode has been set to be context aware
+	 * and we're in a group or viewing a user's profile
+	 * and a group or user hasn't been specified.
+	 */
+	if ( isset( $a['context_aware'] ) && $a['context_aware'] ) {
+		if ( bp_is_user() && ! $doc_args['author_id'] ) {
+			$doc_args['author_id'] = bp_displayed_user_id();
+		}
+		if ( bp_is_group() && ! $doc_args['group_id'] ) {
+			$doc_args['group_id'] = bp_get_current_group_id();
+		}
+	}
+
+	/**
+	 * Filters the args passed to `bp_docs_has_docs()` in the Recent Docs shortcode.
+	 *
+	 * @since 2.3.0
+	 *
+	 * @param array {
+	 *     @type int    $posts_per_page
+	 *     @type string $post_status
+	 *     @type int    $author_id
+	 *     @type int    $group_id
+	 *     @type int    $folder_id
+	 * }
+	 */
+	$doc_args = apply_filters( 'bp_docs_shortcode_query_args', $doc_args );
+
+	$bp = buddypress();
+
+	// Store the existing doc_query, so ours is made from scratch.
+	$temp_doc_query = isset( $bp->bp_docs->doc_query ) ? $bp->bp_docs->doc_query : null;
+	$bp->bp_docs->doc_query = null;
+
+	ob_start();
+
+	if ( bp_docs_has_docs( $doc_args ) ) :
+	?>
+		<ul>
+		<?php while ( bp_docs_has_docs() ) : bp_docs_the_doc(); ?>
+			<li>
+				<a href="<?php the_permalink(); ?>"><?php get_the_title() ? the_title() : the_ID(); ?></a>
+			<?php if ( $a['show_date'] ) : ?>
+				<span class="post-date"><?php echo get_the_date(); ?></span>
+			<?php endif; ?>
+			</li>
+		<?php endwhile; ?>
+	</ul>
+
+	<?php
+	endif;
+
+	$retval = ob_get_clean();
+
+	wp_reset_postdata();
+
+	// Restore the main doc_query; obliterate our secondary loop arguments.
+	$bp->bp_docs->doc_query = $temp_doc_query;
+
+	return $retval;
+}
+add_shortcode( 'bp_docs_recent_docs', 'bp_docs_recent_docs_shortcode_handler' );

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,7 @@ This plugin is in active development. For feature requests and bug reports, visi
 
 = 2.2.0 =
 * Improved hooks for customizing the Docs group admin/create panel.
+* Added a shortcode, `bp_docs_recent_docs`, to output a simple list of docs similar to the Recent Docs widget.
 
 = 2.1.0 =
 * Improved support for BuddyPress 3.0 and the Nouveau template pack.


### PR DESCRIPTION
Shortcode is `bp_docs_recent_docs` and accepts the following parameters:
• number - Max number of docs to show.
• show_date - Whether to display the date after the hyperlinked title.
• author_id - Pass a user ID if you want to limit to docs associated with a particular user.
• group_id - Pass a group ID if you want to limit to docs associated with a particular group.
• folder_id - Pass a folder ID if you want to limit to docs from a folder.
• context aware - If you're using the shortcode within a group or user page, and want to limit the docs to the displayed group or user.