### PR TITLE
Removed {$in_clause} from SQL statement

### DIFF
--- a/includes/addon-wikitext.php
+++ b/includes/addon-wikitext.php
@@ -56,7 +56,7 @@ class BP_Docs_Wikitext {
 		}
 
 		// Look for a page with this title. WP_Query does not allow this for some reason
-		$docs = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $wpdb->posts WHERE post_title = %s AND post_type = %s {$in_clause}", $link_page, bp_docs_get_post_type_name() ) );
+		$docs = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $wpdb->posts WHERE post_title = %s AND post_type = %s", $link_page, bp_docs_get_post_type_name() ) );
 
 		// If none were found, do the same query with page slugs
 		if ( empty( $docs ) ) {

--- a/includes/addon-wikitext.php
+++ b/includes/addon-wikitext.php
@@ -60,7 +60,7 @@ class BP_Docs_Wikitext {
 
 		// If none were found, do the same query with page slugs
 		if ( empty( $docs ) ) {
-			$docs = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $wpdb->posts WHERE post_name = %s AND post_type = %s {$in_clause}", sanitize_title_with_dashes( $link_page ), bp_docs_get_post_type_name() ) );
+			$docs = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $wpdb->posts WHERE post_name = %s AND post_type = %s", sanitize_title_with_dashes( $link_page ), bp_docs_get_post_type_name() ) );
 		}
 
 		// Filter the docs. This will be used to exclude docs that do not belong to a group


### PR DESCRIPTION
$in_clause was removed in this commit https://github.com/boonebgorges/buddypress-docs/commit/bebc29a47c083a2fd4cee37f8956755a0d2dc903, so we get a PHP notice about an undefined variable here. Assuming that this mechanism is no longer needed, the {$in_clause} part of the SQL statement should be removed.