### PR TITLE
Set 'public' taxonomy property to false

### DIFF
--- a/bp-docs.php
+++ b/bp-docs.php
@@ -331,9 +331,8 @@ class BP_Docs {
 		register_taxonomy( $this->associated_item_tax_name, array( $this->post_type_name ), array(
 			'labels'       => $associated_item_labels,
 			'hierarchical' => true,
+			'public'       => false,
 			'show_ui'      => false,
-			'query_var'    => true,
-			'rewrite'      => array( 'slug' => 'item' ),
 		) );
 
 		// Register the bp_docs_access taxonomy

--- a/bp-docs.php
+++ b/bp-docs.php
@@ -339,15 +339,15 @@ class BP_Docs {
 		// Register the bp_docs_access taxonomy
 		register_taxonomy( $this->access_tax_name, array( $this->post_type_name ), array(
 			'hierarchical' => false,
+			'public'       => false,
 			'show_ui'      => false,
-			'query_var'    => false,
 		) );
 
 		// Register the bp_docs_comment_access taxonomy.
 		register_taxonomy( $this->comment_access_tax_name, array( $this->post_type_name ), array(
 			'hierarchical' => false,
+			'public'       => false,
 			'show_ui'      => false,
-			'query_var'    => false,
 		) );
 
 		do_action( 'bp_docs_registered_post_type' );


### PR DESCRIPTION
BuddyPress Docs registers certain taxonomies for internal purposes that should not be public such as `'bp_docs_access'` and `'bp_docs_comment_access'`.

These taxonomies can be exposed when `get_taxonomies( array( 'public' => true ) )` is used. Most prominently is with the `wp-sitemap.xml` file generated by WordPress.

This PR sets the two mentioned taxonomies above to `'public' => false`. One thing I wasn't sure about was the `'bp_docs_associated_item'` taxonomy: https://github.com/boonebgorges/buddypress-docs/blob/d69ab86a2fe6c6f3a61dca6425bc60a9208c3949/bp-docs.php#L333-L340

A rewrite slug is attached to this taxonomy, so I didn't really want to mess with this one without further feedback.