### PR TITLE
Update calls to "_wp_post_revision_field_$field."

### DIFF
--- a/includes/addon-history.php
+++ b/includes/addon-history.php
@@ -221,14 +221,14 @@ class BP_Docs_History {
 
 		foreach ( _wp_post_revision_fields() as $field => $field_title ) {
 			if ( 'diff' == bp_docs_history_action() ) {
-				$left_content = apply_filters( "_wp_post_revision_field_$field", $this->left_revision->$field, $field );
-				$right_content = apply_filters( "_wp_post_revision_field_$field", $this->right_revision->$field, $field );
+				$left_content = apply_filters( "_wp_post_revision_field_$field", $this->left_revision->$field, $field, $this->left_revision, 'from' );
+				$right_content = apply_filters( "_wp_post_revision_field_$field", $this->right_revision->$field, $field, $this->right_revision, 'to' );
 				if ( !$content = wp_text_diff( $left_content, $right_content ) )
 					continue; // There is no difference between left and right
 				$this->revisions_are_identical = false;
 			} else if ( isset( $this->revision ) && is_object( $this->revision ) && isset( $this->revision->$field ) ) {
 				add_filter( "_wp_post_revision_field_$field", 'htmlspecialchars' );
-				$content = apply_filters( "_wp_post_revision_field_$field", $this->revision->$field, $field );
+				$content = apply_filters( "_wp_post_revision_field_$field", $this->revision->$field, $field, $this->revision, 'from' );
 			}
 		}
 	}


### PR DESCRIPTION
Update filter calls to "_wp_post_revision_field_$field" to add the third and fourth parameter. WP 6.3 added a new filter via a
 new footnotes block (https://core.trac.wordpress.org/changeset/56298) that requires the third parameter (the `WP_POST` object), which breaks the `apply_filters()` call in BP Docs. This change adds the third (the `WP_POST` object) and fourth (the context of whether the current revision is the old or the new one) parameter. In our setup, the left revision is always the older version, and the right revision is the newer save.

This new problem was reported here: https://wordpress.org/support/topic/bug-revision-comparison-causes-fatal-error-since-wordpress-6-3/