### PR TITLE
Theme Compat: Return buffer template part

### DIFF
--- a/includes/theme-bridge.php
+++ b/includes/theme-bridge.php
@@ -252,8 +252,7 @@ class BP_Docs_Theme_Compat {
 	 * @since 1.3
 	 */
 	public function directory_content() {
-		bp_buffer_template_part( 'docs/docs-loop' );
-		return '';
+		return bp_buffer_template_part( 'docs/docs-loop', null, false );
 	}
 
 	/** Single ****************************************************************/
@@ -276,8 +275,7 @@ class BP_Docs_Theme_Compat {
 	 * @since 1.3
 	 */
 	public function single_content() {
-		bp_buffer_template_part( $this->single_content_template );
-		return '';
+		return bp_buffer_template_part( $this->single_content_template, null, false );
 	}
 
 	/** Create ****************************************************************/
@@ -307,8 +305,7 @@ class BP_Docs_Theme_Compat {
 	 * @since 1.3
 	 */
 	public function create_content() {
-		bp_buffer_template_part( 'docs/single/edit' );
-		return '';
+		return bp_buffer_template_part( 'docs/single/edit', null, false );
 	}
 }
 new BP_Docs_Theme_Compat();


### PR DESCRIPTION
Came across an issue where on a group doc page, the doc navigation and tabs were displaying twice on the page.

The issue is during theme compat, [bp_buffer_template_part()](https://github.com/buddypress/buddypress/blob/39bba862906314d48eeea11ffc127fc8b8fff8c0/src/bp-core/bp-core-template-loader.php#L401) is being used without setting the `$echo` parameter to `false`. 

This bug also affects BP Docs 2.1.x, so I'm not sure why I'm seeing this problem now :shrug: Anyway, commit 89747f4 fixes this and follows how BP does theme compat for their native components.