### PR TITLE
History: Fix improper redirection for group docs for BuddyPress 12

### DIFF
--- a/includes/addon-history.php
+++ b/includes/addon-history.php
@@ -180,8 +180,10 @@ class BP_Docs_History {
 				}
 			}
 
-			if ( !$post = get_post( $this->revision->post_parent ) )
+			// If revision post parent is empty or no post, bail.
+			if ( empty( $this->revision->post_parent ) || ! $post = get_post( $this->revision->post_parent ) ) {
 				break;
+			}
 
 			// Revisions disabled and we're not looking at an autosave
 			if ( ! wp_revisions_enabled( $post ) && !wp_is_post_autosave( $this->revision ) ) {


### PR DESCRIPTION
I've encountered an issue where group docs are throwing 404s in BuddyPress 12. The group doc URI is appended with `edit.php?post_type=buddypress`, which doesn't exist.

I traced the bug to the history addon.

tl;dr: The simple fix is to check if the revision's post parent is empty before doing anything else.

----

For the rundown, keep on reading. The issue is here:

https://github.com/boonebgorges/buddypress-docs/blob/c4f8c0ec33a63b69bce51c57364f2f9ff4414303/includes/addon-history.php#L183-L184

For a group doc, the `$this->revision->post_parent` is usually `0`. The code is expecting `get_post( $this->revision->post_parent )` to return a falsey value, but it is actually returning the WordPress post of the group directory: https://github.com/WordPress/WordPress/blob/a88967db6eb6a95da6d320d8511f78d00b1ffafd/wp-includes/post.php#L1092-L1095 . (I'm quite certain that BuddyPress 12 is causing the `$GLOBALS['post']` variable to be populated with the group directory post, but I could be wrong. Some particulars about this BP install is BP Classic is not activated, which means BP is using rewrite rules for URI routing.)

Anyway, when the revision's post parent is empty and when there is an already-queried post in the `$post` global, the following occurs:

https://github.com/boonebgorges/buddypress-docs/blob/c4f8c0ec33a63b69bce51c57364f2f9ff4414303/includes/addon-history.php#L186-L190

https://github.com/boonebgorges/buddypress-docs/blob/c4f8c0ec33a63b69bce51c57364f2f9ff4414303/includes/addon-history.php#L205-L206

In the case of the group directory post, revisions and auto-save are not enabled, which causes the group doc to redirect to `/groups/docs/EXAMPLE-DOC/edit.php?post_type=buddypress`. This causes the 404.